### PR TITLE
Raise dependency on icat client to version 4.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 	<repositories>
 		<repository>
 			<id>ICAT Repo</id>
-			<url>http://www.icatproject.org/mvn/repo</url>
+			<url>${repoUrl}</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>org.icatproject</groupId>
 			<artifactId>icat.client</artifactId>
-			<version>4.8.0</version>
+			<version>4.10.1-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
This raises the version in the dependency on icat.client to 4.10.1 (actually, 4.10.1-SNAPSHOT for the moment). This version includes the fix for the character encoding issue.  Close #1.

Note: should wait for icat.client 4.10.1 to be released before merge, hence the draft status of this pull request.