### PR TITLE
Add support for sets via the configuration file

### DIFF
--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -95,8 +95,12 @@
 # Optional condition of set affiliation per set and data configuration
 !sets.exampleSetA.condition.inv = a.modTime >= '2018-07-20 08:00:00' AND a.modTime <= '2018-07-30 08:00:00'
 !sets.exampleSetA.condition.stud = a.modTime <= '2018-07-20 10:00:00'
-!sets.exampleSetB.condition.inv = b.name = 'Nickel' OR b.name = 'Ni'
-!sets.exampleSetB.condition.stud = e.name = 'Nickel' OR e.name = 'Ni'
+!sets.exampleSetB.condition.inv = kw.name = 'Nickel' OR kw.name = 'Ni'
+!sets.exampleSetB.condition.stud = kw.name = 'Nickel' OR kw.name = 'Ni'
+
+# Optional data objects to be joined when retrieving the items of a set
+!sets.exampleSetB.join.inv = JOIN a.keywords AS kw
+!sets.exampleSetB.join.stud = JOIN a.studyInvestigations AS si JOIN si.investigation AS i JOIN i.keywords AS kw
 
 # If set to 'true', metadata won't be transformed into another format
 !responseDebug = true

--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -79,6 +79,21 @@
 !data.stud.studyInvestigations.investigation.investigationUsers.subPropertyLists = user
 !data.stud.studyInvestigations.investigation.investigationUsers.user.stringProperties = fullName givenName familyName orcidId
 
+# A list of sets to be available in the repository (OAI-PMH feature)
+!sets = exampleSetA exampleSetB
+
+# A descriptive name for each set
+!sets.exampleSetA.name = Example Set A
+!sets.exampleSetB.name = Example Set B
+
+# The list of relevant data configurations for each set
+!sets.exampleSetA.configurations = inv stud
+!sets.exampleSetB.configurations = inv
+
+# Optional condition of set affiliation per set and data configuration
+!sets.exampleSetA.condition.inv = a.modTime >= '2018-07-20 08:00:00' AND a.modTime <= '2018-07-30 08:00:00'
+!sets.exampleSetA.condition.stud = a.modTime <= '2018-07-20 10:00:00'
+
 # If set to 'true', metadata won't be transformed into another format
 !responseDebug = true
 

--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -80,19 +80,23 @@
 !data.stud.studyInvestigations.investigation.investigationUsers.user.stringProperties = fullName givenName familyName orcidId
 
 # A list of sets to be available in the repository (OAI-PMH feature)
-!sets = exampleSetA exampleSetB
+!sets = exampleSetA exampleSetB exampleSetC
 
 # A descriptive name for each set
 !sets.exampleSetA.name = Example Set A
 !sets.exampleSetB.name = Example Set B
+!sets.exampleSetC.name = Example Set C
 
 # The list of relevant data configurations for each set
 !sets.exampleSetA.configurations = inv stud
-!sets.exampleSetB.configurations = inv
+!sets.exampleSetB.configurations = inv stud
+!sets.exampleSetC.configurations = inv
 
 # Optional condition of set affiliation per set and data configuration
 !sets.exampleSetA.condition.inv = a.modTime >= '2018-07-20 08:00:00' AND a.modTime <= '2018-07-30 08:00:00'
 !sets.exampleSetA.condition.stud = a.modTime <= '2018-07-20 10:00:00'
+!sets.exampleSetB.condition.inv = b.name = 'Nickel' OR b.name = 'Ni'
+!sets.exampleSetB.condition.stud = e.name = 'Nickel' OR e.name = 'Ni'
 
 # If set to 'true', metadata won't be transformed into another format
 !responseDebug = true

--- a/src/main/java/org/icatproject/icat_oaipmh/DataConfiguration.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/DataConfiguration.java
@@ -8,7 +8,6 @@ public class DataConfiguration {
 
     private ArrayList<String> metadataPrefixes;
     private String mainObject;
-    private String joinedObjects;
     private String includedObjects;
     private RequestedProperties requestedProperties;
 
@@ -21,13 +20,10 @@ public class DataConfiguration {
 
         this.variable = 'a';
         List<String> subObjectsList = extractSubObjects(requestedProperties);
-        if (subObjectsList.isEmpty()) {
-            this.joinedObjects = "";
+        if (subObjectsList.isEmpty())
             this.includedObjects = "";
-        } else {
-            this.joinedObjects = String.format("JOIN %s", String.join(", ", subObjectsList));
+        else
             this.includedObjects = String.format("INCLUDE %s", String.join(", ", subObjectsList));
-        }
     }
 
     private List<String> extractSubObjects(RequestedProperties properties) {
@@ -47,10 +43,6 @@ public class DataConfiguration {
 
     public String getMainObject() {
         return mainObject;
-    }
-
-    public String getJoinedObjects() {
-        return joinedObjects;
     }
 
     public String getIncludedObjects() {

--- a/src/main/java/org/icatproject/icat_oaipmh/DataConfiguration.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/DataConfiguration.java
@@ -8,6 +8,7 @@ public class DataConfiguration {
 
     private ArrayList<String> metadataPrefixes;
     private String mainObject;
+    private String joinedObjects;
     private String includedObjects;
     private RequestedProperties requestedProperties;
 
@@ -19,22 +20,25 @@ public class DataConfiguration {
         this.requestedProperties = requestedProperties;
 
         this.variable = 'a';
-        List<String> includedObjectsList = extractIncludedObjects(requestedProperties);
-        if (includedObjectsList.isEmpty())
+        List<String> subObjectsList = extractSubObjects(requestedProperties);
+        if (subObjectsList.isEmpty()) {
+            this.joinedObjects = "";
             this.includedObjects = "";
-        else
-            this.includedObjects = String.format("INCLUDE %s", String.join(", ", includedObjectsList));
+        } else {
+            this.joinedObjects = String.format("JOIN %s", String.join(", ", subObjectsList));
+            this.includedObjects = String.format("INCLUDE %s", String.join(", ", subObjectsList));
+        }
     }
 
-    private List<String> extractIncludedObjects(RequestedProperties properties) {
+    private List<String> extractSubObjects(RequestedProperties properties) {
         char currentVariable = variable;
-        List<String> includesList = new ArrayList<String>();
+        List<String> subList = new ArrayList<String>();
         for (RequestedProperties props : properties.getSubPropertyLists()) {
             variable++;
-            includesList.add(String.format("%s.%s %s", currentVariable, props.getIcatObject(), variable));
-            includesList.addAll(extractIncludedObjects(props));
+            subList.add(String.format("%s.%s %s", currentVariable, props.getIcatObject(), variable));
+            subList.addAll(extractSubObjects(props));
         }
-        return includesList;
+        return subList;
     }
 
     public ArrayList<String> getMetadataPrefixes() {
@@ -43,6 +47,10 @@ public class DataConfiguration {
 
     public String getMainObject() {
         return mainObject;
+    }
+
+    public String getJoinedObjects() {
+        return joinedObjects;
     }
 
     public String getIncludedObjects() {

--- a/src/main/java/org/icatproject/icat_oaipmh/ItemSet.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ItemSet.java
@@ -6,14 +6,20 @@ public class ItemSet {
 
     private String setName;
     private HashMap<String, String> dataConfigurationsConditions;
+    private HashMap<String, String> dataConfigurationsJoins;
 
     public ItemSet(String setName) {
         this.setName = setName;
         this.dataConfigurationsConditions = new HashMap<String, String>();
+        this.dataConfigurationsJoins = new HashMap<String, String>();
     }
 
     public void addDataConfigurationCondition(String dataConfigurationIdentifier, String condition) {
         this.dataConfigurationsConditions.put(dataConfigurationIdentifier, condition);
+    }
+
+    public void addDataConfigurationJoin(String dataConfigurationIdentifier, String join) {
+        this.dataConfigurationsJoins.put(dataConfigurationIdentifier, join);
     }
 
     public String getSetName() {
@@ -22,5 +28,9 @@ public class ItemSet {
 
     public HashMap<String, String> getDataConfigurationsConditions() {
         return dataConfigurationsConditions;
+    }
+
+    public HashMap<String, String> getDataConfigurationsJoins() {
+        return dataConfigurationsJoins;
     }
 }

--- a/src/main/java/org/icatproject/icat_oaipmh/ItemSet.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ItemSet.java
@@ -1,0 +1,26 @@
+package org.icatproject.icat_oaipmh;
+
+import java.util.HashMap;
+
+public class ItemSet {
+
+    private String setName;
+    private HashMap<String, String> dataConfigurationsConditions;
+
+    public ItemSet(String setName) {
+        this.setName = setName;
+        this.dataConfigurationsConditions = new HashMap<String, String>();
+    }
+
+    public void addDataConfigurationCondition(String dataConfigurationIdentifier, String condition) {
+        this.dataConfigurationsConditions.put(dataConfigurationIdentifier, condition);
+    }
+
+    public String getSetName() {
+        return setName;
+    }
+
+    public HashMap<String, String> getDataConfigurationsConditions() {
+        return dataConfigurationsConditions;
+    }
+}

--- a/src/main/java/org/icatproject/icat_oaipmh/RequestHandler.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/RequestHandler.java
@@ -36,6 +36,10 @@ public class RequestHandler {
         rb.addDataConfiguration(identifier, configuration);
     }
 
+    public void registerSet(String setSpec, ItemSet set) {
+        rb.addSet(setSpec, set);
+    }
+
     public String request(HttpServletRequest req) throws InternalException {
         XmlResponse res = new XmlResponse();
         String[] verbs = req.getParameterValues("verb");
@@ -101,7 +105,7 @@ public class RequestHandler {
 
     private String handleListSets(HttpServletRequest req, XmlResponse res, Templates template)
             throws InternalException {
-        String[] allowedParameters = { "verb", "resumptionToken" };
+        String[] allowedParameters = { "verb" };
         String[] requiredParameters = {};
 
         if (checkParameters(allowedParameters, requiredParameters, req, res)) {

--- a/src/main/java/org/icatproject/icat_oaipmh/RequestInterface.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/RequestInterface.java
@@ -116,11 +116,17 @@ public class RequestInterface {
 					String[] setDataConfigurations = props.getString(propName).split("\\s+");
 					for (String setDataConfiguration : setDataConfigurations) {
 						String condition = null;
+						String join = null;
 						propName = String.format("sets.%s.condition.%s", setSpec, setDataConfiguration);
 						if (props.has(propName)) {
 							condition = props.getString(propName);
 						}
+						propName = String.format("sets.%s.join.%s", setSpec, setDataConfiguration);
+						if (props.has(propName)) {
+							join = props.getString(propName);
+						}
 						set.addDataConfigurationCondition(setDataConfiguration, condition);
+						set.addDataConfigurationJoin(setDataConfiguration, join);
 					}
 					bean.registerSet(setSpec, set);
 				}
@@ -133,7 +139,7 @@ public class RequestInterface {
 			throw new IllegalStateException();
 		}
 
-		logger.info("Initialised RequestInterface");
+		logger.info("Initialized RequestInterface");
 	}
 
 	private RequestedProperties getRequestedProperties(CheckedProperties props, String prefix, String object)

--- a/src/main/java/org/icatproject/icat_oaipmh/RequestInterface.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/RequestInterface.java
@@ -103,6 +103,28 @@ public class RequestInterface {
 						requestedProperties);
 				bean.registerDataConfiguration(identifier, dataConfiguration);
 			}
+
+			if (props.has("sets")) {
+				String[] sets = props.getString("sets").split("\\s+");
+				for (String setSpec : sets) {
+					propName = String.format("sets.%s.name", setSpec);
+					String setName = props.getString(propName);
+
+					ItemSet set = new ItemSet(setName);
+
+					propName = String.format("sets.%s.configurations", setSpec);
+					String[] setDataConfigurations = props.getString(propName).split("\\s+");
+					for (String setDataConfiguration : setDataConfigurations) {
+						String condition = null;
+						propName = String.format("sets.%s.condition.%s", setSpec, setDataConfiguration);
+						if (props.has(propName)) {
+							condition = props.getString(propName);
+						}
+						set.addDataConfigurationCondition(setDataConfiguration, condition);
+					}
+					bean.registerSet(setSpec, set);
+				}
+			}
 		} catch (CheckedPropertyException | FileNotFoundException | SecurityException | NumberFormatException
 				| TransformerConfigurationException | URISyntaxException e) {
 			logger.error(fatal, e.getMessage());

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -350,11 +350,12 @@ public class ResponseBuilder {
             }
 
             String mainObject = dataConfiguration.getMainObject();
+            String join = dataConfiguration.getJoinedObjects();
             String includes = dataConfiguration.getIncludedObjects();
             String where = parameters.makeWhereCondition(dataConfigurationIdentifier, setCondition);
             Integer queryLimit = new Integer(remainingResults + 1);
-            String query = String.format("SELECT a FROM %s a %s ORDER BY a.id LIMIT 0,%s %s", mainObject, where,
-                    queryLimit, includes);
+            String query = String.format("SELECT DISTINCT a FROM %s a %s %s ORDER BY a.id LIMIT 0,%s %s", mainObject,
+                    join, where, queryLimit, includes);
 
             String result = queryIcat(query);
             JsonReader jsonReader = Json.createReader(new StringReader(result));
@@ -377,7 +378,8 @@ public class ResponseBuilder {
             for (Map.Entry<String, ItemSet> set : sets.entrySet()) {
                 String condition = set.getValue().getDataConfigurationsConditions().get(dataConfigurationIdentifier);
                 if (condition != null) {
-                    String setQuery = String.format("SELECT a.id FROM %s a WHERE %s", mainObject, condition);
+                    String setQuery = String.format("SELECT DISTINCT a.id FROM %s a %s WHERE %s", mainObject, join,
+                            condition);
                     String setObjects = queryIcat(setQuery);
 
                     JsonReader setJsonReader = Json.createReader(new StringReader(setObjects));

--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -23,6 +23,7 @@ if arg == "INSTALL":
 
     metadataPrefixes = properties["metadataPrefixes"].split()
     dataConfigurations = properties["data.configurations"].split()
+    sets = properties["sets"].split()
 
     try:
         val = int(properties["maxResults"])
@@ -35,6 +36,8 @@ if arg == "INSTALL":
         abort("Support for the metadataPrefix 'oai_dc' is missing in run.properties")
 
     for v in dataConfigurations:
+        if "," in v:
+            abort("The value '" + v + "' in data.configurations list must not contain a comma in run.properties")
         if "data." + v + ".mainObject" not in properties:
             abort("data.configurations include '" + v + "' but 'data." + v + ".mainObject' is not defined in run.properties")
         if "data." + v + ".metadataPrefixes" not in properties:
@@ -57,6 +60,19 @@ if arg == "INSTALL":
         if "responseDebug" not in properties or properties["responseDebug"] != "true":
             if not os.path.exists(properties[v + ".xslt"]):
                 abort("The file '" + properties[v + ".xslt"] + "' as listed in run.properties for '" + v + ".xslt' does not exist on your system")
+
+    for v in sets:
+        if "," in v:
+            abort("The value '" + v + "' in sets list must not contain a comma in run.properties")
+        if "sets." + v + ".name" not in properties:
+            abort("sets include '" + v + "' but 'sets." + v + ".name' is not defined in run.properties")
+        if "sets." + v + ".configurations" not in properties:
+            abort("sets include '" + v + "' but 'sets." + v + ".configurations' is not defined in run.properties")
+
+        setDataConfigurations = properties["sets." + v + ".configurations"].split()
+        for w in setDataConfigurations:
+            if w not in dataConfigurations:
+                abort("sets." + v + ".configurations include '" + w + "' but this data configuration is not defined in run.properties")
 
     try:
         undeploy()

--- a/src/site/xhtml/installation.xhtml.vm
+++ b/src/site/xhtml/installation.xhtml.vm
@@ -334,7 +334,7 @@
 			Each set must be defined using a unique identifier string.
 		</dd>
 		<dd>
-			Example value: <b>"exampleSetA exampleSetB"</b>
+			Example value: <b>"exampleSetA exampleSetB exampleSetC"</b>
 		</dd>
 		<dt>sets.&lt;set&gt;.name</dt>
 		<dd>
@@ -351,18 +351,22 @@
 			will be affiliated with the set.
 		</dd>
 		<dd>
-			For example, if the <code>sets</code> are <b>"exampleSetA exampleSetB"</b> and
+			For example, if the <code>sets</code> are <b>"exampleSetA exampleSetB exampleSetC"</b> and
 			the <code>data.configurations</code> are <b>"inv stud"</b> where
 			<code>data.inv.mainObject</code> is set to <b>"Investigation"</b> and
 			<code>data.stud.mainObject</code> is set to <b>"Study"</b>, one might use:
 			<ul>
 				<li>
 					<b>"sets.exampleSetA.configurations = inv stud"</b> to say that the set
-					<b>"exampleSetA"</b> shall consist of both Investigations and Studies, and
+					<b>"exampleSetA"</b> shall consist of both Investigations and Studies,
 				</li>
 				<li>
-					<b>"sets.exampleSetB.configurations = inv"</b> to say that the set
-					<b>"exampleSetB"</b> shall consist only of Investigations.
+					<b>"sets.exampleSetB.configurations = inv stud"</b> to say that the set
+					<b>"exampleSetB"</b> shall also consist of both Investigations and Studies, and
+				</li>
+				<li>
+					<b>"sets.exampleSetC.configurations = inv"</b> to say that the set
+					<b>"exampleSetC"</b> shall consist only of Investigations.
 				</li>
 			</ul>
 		</dd>
@@ -373,16 +377,30 @@
 		</dd>
 		<dd>
 			Conditions must be defined using regular ICAT query syntax.
-			Please use the entity variable <b>"a"</b>, as seen below.
+			Use the entity variable <b>"a"</b> to access the attributes of the configured main object,
+			e.g. <b>"a.modTime"</b>, and use subsequent letters for included objects.
 		</dd>
 		<dd>
-			For example, if the <code>sets</code> include <b>"exampleSetA"</b> and
-			the <code>sets.exampleSetA.configurations</code> include <b>"stud"</b>, one might use:
+			For example, if the <code>sets</code> are <b>"exampleSetA exampleSetB exampleSetC"</b>,
+			the <code>sets.exampleSetA.configurations</code> are <b>"inv stud"</b>,
+			the <code>sets.exampleSetB.configurations</code> are <b>"inv stud"</b>, and 
+			the <code>sets.exampleSetC.configurations</code> are <b>"inv"</b>, one might use:
 			<ul>
 				<li>
 					<b>"sets.exampleSetA.condition.stud = a.modTime <= '2018-07-20 10:00:00'"</b>
 					to say that Studies shall only be affiliated with the set <b>"exampleSetA"</b>
 					if they were modified before 2018-07-20 10:00:00.
+				</li>
+				<li>
+					<b>"sets.exampleSetB.condition.inv = b.name = 'Nickel' OR b.name = 'Ni'"</b>
+					to say that Investigations shall only be affiliated with the set <b>"exampleSetB"</b>
+					if they are related to a keyword with name "Nickel" or "Ni". In this example, it is assumed
+					that the first entry in <code>data.inv.subPropertyLists</code> is <b>"keywords"</b>,
+					hence the letter <b>"b"</b> is used in the query.
+				</li>
+				<li>
+					Leave <b>"sets.exampleSetC.condition.inv"</b> blank to say that <i>all</i> Investigations
+					shall unconditionally be affiliated with the set <b>"exampleSetC"</b>.
 				</li>
 			</ul>
 		</dd>

--- a/src/site/xhtml/installation.xhtml.vm
+++ b/src/site/xhtml/installation.xhtml.vm
@@ -345,114 +345,134 @@
 		</dd>
 		<dt>sets</dt>
 		<dd>
-			A space separated list of sets to be available in the repository (optional).
+			A space separated list of sets to be available in the repository
+			(optional).
 		</dd>
 		<dd>
-			Sets can be used to group items for the purpose of selective harvesting.
-			Each set must be defined using a unique identifier string.
+			Sets can be used to group items for the purpose of selective
+			harvesting. Each set must be defined using a unique identifier
+			string.
 		</dd>
 		<dd>
 			Example value: <b>"exampleSetA exampleSetB exampleSetC"</b>
 		</dd>
 		<dt>sets.&lt;set&gt;.name</dt>
 		<dd>
-			For each set, specify a descriptive, human readable name.
-			This will be returned as part of the OAI-PMH "ListSets" response.
+			For each set, specify a descriptive, human readable name. This will
+			be returned as part of the OAI-PMH "ListSets" response.
 		</dd>
 		<dd>
 			Example: <b>"sets.exampleSetA.name = Example Set A"</b>
 		</dd>
 		<dt>sets.&lt;set&gt;.configurations</dt>
 		<dd>
-			For each set, specify a space separated list of relevant data configurations.
-			If no further conditions are applied, all items of the relevant data configurations
-			will be affiliated with the set.
+			For each set, specify a space separated list of relevant data
+			configurations. If no further conditions are applied, all items of
+			the relevant data configurations will be affiliated with the set.
 		</dd>
 		<dd>
-			For example, if the <code>sets</code> are <b>"exampleSetA exampleSetB exampleSetC"</b> and
-			the <code>data.configurations</code> are <b>"inv stud"</b> where
-			<code>data.inv.mainObject</code> is set to <b>"Investigation"</b> and
-			<code>data.stud.mainObject</code> is set to <b>"Study"</b>, one might use:
+			For example, if the <code>sets</code> are
+			<b>"exampleSetA exampleSetB exampleSetC"</b> and the
+			<code>data.configurations</code> are <b>"inv stud"</b> where
+			<code>data.inv.mainObject</code> is set to <b>"Investigation"</b>
+			and <code>data.stud.mainObject</code> is set to <b>"Study"</b>, one
+			might use:
 			<ul>
 				<li>
-					<b>"sets.exampleSetA.configurations = inv stud"</b> to say that the set
-					<b>"exampleSetA"</b> shall consist of both Investigations and Studies,
+					<b>"sets.exampleSetA.configurations = inv stud"</b> to say
+					that the set <b>"exampleSetA"</b> shall consist of both
+					Investigations and Studies,
 				</li>
 				<li>
-					<b>"sets.exampleSetB.configurations = inv stud"</b> to say that the set
-					<b>"exampleSetB"</b> shall also consist of both Investigations and Studies, and
+					<b>"sets.exampleSetB.configurations = inv stud"</b> to say
+					that the set <b>"exampleSetB"</b> shall also consist of both
+					Investigations and Studies, and
 				</li>
 				<li>
-					<b>"sets.exampleSetC.configurations = inv"</b> to say that the set
-					<b>"exampleSetC"</b> shall consist only of Investigations.
+					<b>"sets.exampleSetC.configurations = inv"</b> to say that
+					the set <b>"exampleSetC"</b> shall consist only of
+					Investigations.
 				</li>
 			</ul>
 		</dd>
 		<dt>sets.&lt;set&gt;.condition.&lt;configuration&gt;</dt>
 		<dd>
-			For each set and each data configuration, optionally specify an additional condition.
-			Only items that meet this condition will be affiliated with the set.
+			For each set and each data configuration, optionally specify an
+			additional condition. Only items that meet this condition will be
+			affiliated with the set.
 		</dd>
 		<dd>
-			Conditions must be defined using regular ICAT query syntax.
-			Use the entity variable <b>"a"</b> to access the attributes of the configured main object,
-			e.g. <b>"a.modTime"</b>, and use custom entity variables for related objects
-			(see <code>sets.&lt;set&gt;.join.*</code> below).
+			Conditions must be defined using regular ICAT query syntax. Use the
+			entity variable <b>"a"</b> to access the attributes of the
+			configured main object, e.g. <b>"a.modTime"</b>, and use custom
+			entity variables for related objects (see
+			<code>sets.&lt;set&gt;.join.*</code> below).
 		</dd>
 		<dd>
-			For example, if the <code>sets</code> are <b>"exampleSetA exampleSetB exampleSetC"</b>,
-			the <code>sets.exampleSetA.configurations</code> are <b>"inv stud"</b>,
-			the <code>sets.exampleSetB.configurations</code> are <b>"inv stud"</b>, and
-			the <code>sets.exampleSetC.configurations</code> are <b>"inv"</b>, one might use:
+			For example, if the <code>sets</code> are
+			<b>"exampleSetA exampleSetB exampleSetC"</b>, the
+			<code>sets.exampleSetA.configurations</code> are <b>"inv stud"</b>,
+			the <code>sets.exampleSetB.configurations</code> are
+			<b>"inv stud"</b>, and the
+			<code>sets.exampleSetC.configurations</code> are <b>"inv"</b>, one
+			might use:
 			<ul>
 				<li>
 					<b>"sets.exampleSetA.condition.stud = a.modTime <= '2018-07-20 10:00:00'"</b>
-					to say that Studies shall only be affiliated with the set <b>"exampleSetA"</b>
-					if they were modified before 2018-07-20 10:00:00.
+					to say that Studies shall only be affiliated with the set
+					<b>"exampleSetA"</b> if they were modified before 2018-07-20
+					10:00:00.
 				</li>
 				<li>
 					<b>"sets.exampleSetB.condition.inv = kw.name = 'Nickel' OR kw.name = 'Ni'"</b>
-					to say that Investigations shall only be affiliated with the set <b>"exampleSetB"</b>
-					if they are related to a keyword with name "Nickel" or "Ni". In this example, it is assumed
-					that <code>sets.exampleSetB.join.inv</code> is set to <b>"JOIN a.keywords AS kw"</b>,
-					hence the entity variable <b>"kw"</b> is used in the query.
+					to say that Investigations shall only be affiliated with the
+					set <b>"exampleSetB"</b> if they are related to a keyword
+					with name "Nickel" or "Ni". In this example, it is assumed
+					that <code>sets.exampleSetB.join.inv</code> is set to
+					<b>"JOIN a.keywords AS kw"</b>, hence the entity variable
+					<b>"kw"</b> is used in the query.
 				</li>
 				<li>
-					Leave <b>"sets.exampleSetC.condition.inv"</b> blank to say that <i>all</i> Investigations
-					shall be affiliated with the set <b>"exampleSetC"</b>.
+					Leave <b>"sets.exampleSetC.condition.inv"</b> blank to say
+					that <i>all</i> Investigations shall be affiliated with the
+					set <b>"exampleSetC"</b>.
 				</li>
 			</ul>
 		</dd>
 		<dt>sets.&lt;set&gt;.join.&lt;configuration&gt;</dt>
 		<dd>
-			For each set and each data configuration, optionally specify additional data objects to be joined
-			when retrieving the items of the set.
+			For each set and each data configuration, optionally specify
+			additional data objects to be joined when retrieving the items of
+			the set.
 		</dd>
 		<dd>
-			This may be needed to be able to specify certain conditions
-			(see <code>sets.&lt;set&gt;.condition.*</code> above).
+			This may be needed to be able to specify certain conditions (see
+			<code>sets.&lt;set&gt;.condition.*</code> above).
 		</dd>
 		<dd>
-			Use the entity variable <b>"a"</b> to access the relations of the configured main object,
-			e.g. <b>"JOIN a.keywords AS kw"</b>.
+			Use the entity variable <b>"a"</b> to access the relations of the
+			configured main object, e.g. <b>"JOIN a.keywords AS kw"</b>.
 		</dd>
 		<dd>
-			For example, if the <code>sets</code> include <b>"exampleSetB"</b> and
-			the <code>sets.exampleSetB.configurations</code> are <b>"inv stud"</b> where
-			<code>data.inv.mainObject</code> is set to <b>"Investigation"</b> and
-			<code>data.stud.mainObject</code> is set to <b>"Study"</b>, one might use:
+			For example, if the <code>sets</code> include <b>"exampleSetB"</b>
+			and the <code>sets.exampleSetB.configurations</code> are
+			<b>"inv stud"</b> where <code>data.inv.mainObject</code> is set to
+			<b>"Investigation"</b> and <code>data.stud.mainObject</code> is set
+			to <b>"Study"</b>, one might use:
 			<ul>
 				<li>
-					<b>"sets.exampleSetB.join.inv = JOIN a.keywords AS kw"</b> to say that
-					in the query used to retrieve the Investigations related to the set <b>"exampleSetB"</b>,
-					the related keywords shall be joined and made accessible as entity variable <b>"kw"</b>.
+					<b>"sets.exampleSetB.join.inv = JOIN a.keywords AS kw"</b>
+					to say that in the query used to retrieve the Investigations
+					related to the set <b>"exampleSetB"</b>, the related
+					keywords shall be joined and made accessible as entity
+					variable <b>"kw"</b>.
 				</li>
 				<li>
-					<b>"sets.exampleSetB.join.stud =
-						JOIN a.studyInvestigations AS si JOIN si.investigation AS i JOIN i.keywords AS kw"</b>
-					to say that in the query used to retrieve the Studies related to the set <b>"exampleSetB"</b>,
-					the keywords of the related studyInvestigations shall be joined and made accessible
-					as entity variable <b>"kw"</b>.
+					<b>"sets.exampleSetB.join.stud = JOIN a.studyInvestigations AS si JOIN si.investigation AS i JOIN i.keywords AS kw"</b>
+					to say that in the query used to retrieve the Studies
+					related to the set <b>"exampleSetB"</b>, the keywords of the
+					related studyInvestigations shall be joined and made
+					accessible as entity variable <b>"kw"</b>.
 				</li>
 			</ul>
 		</dd>

--- a/src/site/xhtml/installation.xhtml.vm
+++ b/src/site/xhtml/installation.xhtml.vm
@@ -378,12 +378,13 @@
 		<dd>
 			Conditions must be defined using regular ICAT query syntax.
 			Use the entity variable <b>"a"</b> to access the attributes of the configured main object,
-			e.g. <b>"a.modTime"</b>, and use subsequent letters for included objects.
+			e.g. <b>"a.modTime"</b>, and use custom entity variables for related objects
+			(see <code>sets.&lt;set&gt;.join.*</code> below).
 		</dd>
 		<dd>
 			For example, if the <code>sets</code> are <b>"exampleSetA exampleSetB exampleSetC"</b>,
 			the <code>sets.exampleSetA.configurations</code> are <b>"inv stud"</b>,
-			the <code>sets.exampleSetB.configurations</code> are <b>"inv stud"</b>, and 
+			the <code>sets.exampleSetB.configurations</code> are <b>"inv stud"</b>, and
 			the <code>sets.exampleSetC.configurations</code> are <b>"inv"</b>, one might use:
 			<ul>
 				<li>
@@ -392,15 +393,48 @@
 					if they were modified before 2018-07-20 10:00:00.
 				</li>
 				<li>
-					<b>"sets.exampleSetB.condition.inv = b.name = 'Nickel' OR b.name = 'Ni'"</b>
+					<b>"sets.exampleSetB.condition.inv = kw.name = 'Nickel' OR kw.name = 'Ni'"</b>
 					to say that Investigations shall only be affiliated with the set <b>"exampleSetB"</b>
 					if they are related to a keyword with name "Nickel" or "Ni". In this example, it is assumed
-					that the first entry in <code>data.inv.subPropertyLists</code> is <b>"keywords"</b>,
-					hence the letter <b>"b"</b> is used in the query.
+					that <code>sets.exampleSetB.join.inv</code> is set to <b>"JOIN a.keywords AS kw"</b>,
+					hence the entity variable <b>"kw"</b> is used in the query.
 				</li>
 				<li>
 					Leave <b>"sets.exampleSetC.condition.inv"</b> blank to say that <i>all</i> Investigations
-					shall unconditionally be affiliated with the set <b>"exampleSetC"</b>.
+					shall be affiliated with the set <b>"exampleSetC"</b>.
+				</li>
+			</ul>
+		</dd>
+		<dt>sets.&lt;set&gt;.join.&lt;configuration&gt;</dt>
+		<dd>
+			For each set and each data configuration, optionally specify additional data objects to be joined
+			when retrieving the items of the set.
+		</dd>
+		<dd>
+			This may be needed to be able to specify certain conditions
+			(see <code>sets.&lt;set&gt;.condition.*</code> above).
+		</dd>
+		<dd>
+			Use the entity variable <b>"a"</b> to access the relations of the configured main object,
+			e.g. <b>"JOIN a.keywords AS kw"</b>.
+		</dd>
+		<dd>
+			For example, if the <code>sets</code> include <b>"exampleSetB"</b> and
+			the <code>sets.exampleSetB.configurations</code> are <b>"inv stud"</b> where
+			<code>data.inv.mainObject</code> is set to <b>"Investigation"</b> and
+			<code>data.stud.mainObject</code> is set to <b>"Study"</b>, one might use:
+			<ul>
+				<li>
+					<b>"sets.exampleSetB.join.inv = JOIN a.keywords AS kw"</b> to say that
+					in the query used to retrieve the Investigations related to the set <b>"exampleSetB"</b>,
+					the related keywords shall be joined and made accessible as entity variable <b>"kw"</b>.
+				</li>
+				<li>
+					<b>"sets.exampleSetB.join.stud =
+						JOIN a.studyInvestigations AS si JOIN si.investigation AS i JOIN i.keywords AS kw"</b>
+					to say that in the query used to retrieve the Studies related to the set <b>"exampleSetB"</b>,
+					the keywords of the related studyInvestigations shall be joined and made accessible
+					as entity variable <b>"kw"</b>.
 				</li>
 			</ul>
 		</dd>

--- a/src/site/xhtml/installation.xhtml.vm
+++ b/src/site/xhtml/installation.xhtml.vm
@@ -325,6 +325,67 @@
 				</li>
 			</ul>
 		</dd>
+		<dt>sets</dt>
+		<dd>
+			A space separated list of sets to be available in the repository (optional).
+		</dd>
+		<dd>
+			Sets can be used to group items for the purpose of selective harvesting.
+			Each set must be defined using a unique identifier string.
+		</dd>
+		<dd>
+			Example value: <b>"exampleSetA exampleSetB"</b>
+		</dd>
+		<dt>sets.&lt;set&gt;.name</dt>
+		<dd>
+			For each set, specify a descriptive, human readable name.
+			This will be returned as part of the OAI-PMH "ListSets" response.
+		</dd>
+		<dd>
+			Example: <b>"sets.exampleSetA.name = Example Set A"</b>
+		</dd>
+		<dt>sets.&lt;set&gt;.configurations</dt>
+		<dd>
+			For each set, specify a space separated list of relevant data configurations.
+			If no further conditions are applied, all items of the relevant data configurations
+			will be affiliated with the set.
+		</dd>
+		<dd>
+			For example, if the <code>sets</code> are <b>"exampleSetA exampleSetB"</b> and
+			the <code>data.configurations</code> are <b>"inv stud"</b> where
+			<code>data.inv.mainObject</code> is set to <b>"Investigation"</b> and
+			<code>data.stud.mainObject</code> is set to <b>"Study"</b>, one might use:
+			<ul>
+				<li>
+					<b>"sets.exampleSetA.configurations = inv stud"</b> to say that the set
+					<b>"exampleSetA"</b> shall consist of both Investigations and Studies, and
+				</li>
+				<li>
+					<b>"sets.exampleSetB.configurations = inv"</b> to say that the set
+					<b>"exampleSetB"</b> shall consist only of Investigations.
+				</li>
+			</ul>
+		</dd>
+		<dt>sets.&lt;set&gt;.condition.&lt;configuration&gt;</dt>
+		<dd>
+			For each set and each data configuration, optionally specify an additional condition.
+			Only items that meet this condition will be affiliated with the set.
+		</dd>
+		<dd>
+			Conditions must be defined using regular ICAT query syntax.
+			Please use the entity variable <b>"a"</b>, as seen below.
+		</dd>
+		<dd>
+			For example, if the <code>sets</code> include <b>"exampleSetA"</b> and
+			the <code>sets.exampleSetA.configurations</code> include <b>"stud"</b>, one might use:
+			<ul>
+				<li>
+					<b>"sets.exampleSetA.condition.stud = a.modTime <= '2018-07-20 10:00:00'"</b>
+					to say that Studies shall only be affiliated with the set <b>"exampleSetA"</b>
+					if they were modified before 2018-07-20 10:00:00.
+				</li>
+			</ul>
+		</dd>
 		<dt>responseDebug</dt>
 		<dd>
 			If this (optional) parameter is included and set to <b>"true"</b>, the metadata

--- a/src/test/java/org/icatproject/icat_oaipmh/integration/TestVerbs.java
+++ b/src/test/java/org/icatproject/icat_oaipmh/integration/TestVerbs.java
@@ -217,6 +217,9 @@ public class TestVerbs extends BaseTest {
 		Node header = getXmlNode(response, "header");
 		String identifier = getXmlChild(header, "identifier").getTextContent();
 		assertEquals(investigationUniqueIdentifier, identifier);
+
+		Node setSpec = getXmlNode(response, "setSpec");
+		assertEquals("exampleSetB", setSpec.getTextContent());
 	}
 
 	@Test
@@ -228,6 +231,8 @@ public class TestVerbs extends BaseTest {
 		Node header = getXmlNode(response, "header");
 		String identifier = getXmlChild(header, "identifier").getTextContent();
 		assertEquals(studyUniqueIdentifier, identifier);
+
+		getXmlNodes(response, "setSpec", 0);
 	}
 
 	@Test
@@ -263,7 +268,7 @@ public class TestVerbs extends BaseTest {
 	@Test
 	public void testListIdentifiersResumptionTokenAndAdditionalArguments() throws Exception {
 		Document response = request(
-				"?verb=ListIdentifiers&metadataPrefix=oai_dc&resumptionToken=oai_dc,inv/1,null,null");
+				"?verb=ListIdentifiers&metadataPrefix=oai_dc&resumptionToken=oai_dc,inv/1,null,null,null");
 
 		Node error = getXmlNode(response, "error");
 		NamedNodeMap attributes = error.getAttributes();
@@ -273,7 +278,7 @@ public class TestVerbs extends BaseTest {
 
 	@Test
 	public void testListIdentifiersInvalidResumptionTokenMetadataFormat() throws Exception {
-		Document response = request("?verb=ListIdentifiers&resumptionToken=invalid,inv/1,null,null");
+		Document response = request("?verb=ListIdentifiers&resumptionToken=invalid,inv/1,null,null,null");
 
 		Node error = getXmlNode(response, "error");
 		NamedNodeMap attributes = error.getAttributes();
@@ -312,11 +317,11 @@ public class TestVerbs extends BaseTest {
 	}
 
 	@Test
-	public void testListIdentifiersWithResumptionToken() throws Exception {
+	public void testListIdentifiersWithResumptionTokenAndSet() throws Exception {
 		Document response;
 		String resumptionToken;
 
-		response = request("?verb=ListIdentifiers&metadataPrefix=oai_datacite");
+		response = request("?verb=ListIdentifiers&metadataPrefix=oai_dc&set=exampleSetB");
 
 		getXmlNode(response, "ListIdentifiers");
 		getXmlNodes(response, "header", 2);
@@ -334,7 +339,7 @@ public class TestVerbs extends BaseTest {
 	@Test
 	public void testListIdentifiersWithResumptionTokenAndTimespan() throws Exception {
 		Document response = request(
-				"?verb=ListIdentifiers&resumptionToken=oai_dc,inv/1,2018-07-01T00:00:00Z,2018-07-15T00:00:00Z");
+				"?verb=ListIdentifiers&resumptionToken=oai_dc,inv/1,2018-07-01T00:00:00Z,2018-07-15T00:00:00Z,null");
 
 		getXmlNode(response, "ListIdentifiers");
 		getXmlNodes(response, "header", 1);
@@ -366,6 +371,27 @@ public class TestVerbs extends BaseTest {
 		NamedNodeMap attributes = error.getAttributes();
 		Node errorCode = attributes.getNamedItem("code");
 		assertEquals("badArgument", errorCode.getTextContent());
+	}
+
+	@Test
+	public void testListIdentifiersWithSet() throws Exception {
+		Document response = request("?verb=ListIdentifiers&metadataPrefix=oai_dc&set=exampleSetA");
+
+		getXmlNode(response, "ListIdentifiers");
+		getXmlNodes(response, "header", 2);
+
+		String resumptionToken = getXmlNode(response, "resumptionToken").getTextContent();
+		assertEquals("", resumptionToken);
+	}
+
+	@Test
+	public void testListIdentifiersWithUndefinedSet() throws Exception {
+		Document response = request("?verb=ListIdentifiers&metadataPrefix=oai_dc&set=undefined");
+
+		Node error = getXmlNode(response, "error");
+		NamedNodeMap attributes = error.getAttributes();
+		Node errorCode = attributes.getNamedItem("code");
+		assertEquals("noRecordsMatch", errorCode.getTextContent());
 	}
 
 	@Test
@@ -401,7 +427,7 @@ public class TestVerbs extends BaseTest {
 	@Test
 	public void testListRecordsResumptionTokenAndAdditionalArguments() throws Exception {
 		Document response = request(
-				"?verb=ListRecords&metadataPrefix=oai_dc&resumptionToken=oai_dc,inv/1,null,null");
+				"?verb=ListRecords&metadataPrefix=oai_dc&resumptionToken=oai_dc,inv/1,null,null,null");
 
 		Node error = getXmlNode(response, "error");
 		NamedNodeMap attributes = error.getAttributes();
@@ -411,7 +437,7 @@ public class TestVerbs extends BaseTest {
 
 	@Test
 	public void testListRecordsInvalidResumptionTokenMetadataFormat() throws Exception {
-		Document response = request("?verb=ListRecords&resumptionToken=invalid,inv/1,null,null");
+		Document response = request("?verb=ListRecords&resumptionToken=invalid,inv/1,null,null,null");
 
 		Node error = getXmlNode(response, "error");
 		NamedNodeMap attributes = error.getAttributes();
@@ -450,11 +476,11 @@ public class TestVerbs extends BaseTest {
 	}
 
 	@Test
-	public void testListRecordsWithResumptionToken() throws Exception {
+	public void testListRecordsWithResumptionTokenAndSet() throws Exception {
 		Document response;
 		String resumptionToken;
 
-		response = request("?verb=ListRecords&metadataPrefix=oai_datacite");
+		response = request("?verb=ListRecords&metadataPrefix=oai_dc&set=exampleSetB");
 
 		getXmlNode(response, "ListRecords");
 		getXmlNodes(response, "record", 2);
@@ -472,7 +498,7 @@ public class TestVerbs extends BaseTest {
 	@Test
 	public void testListRecordsWithResumptionTokenAndTimespan() throws Exception {
 		Document response = request(
-				"?verb=ListRecords&resumptionToken=oai_dc,inv/1,2018-07-01T00:00:00Z,2018-07-15T00:00:00Z");
+				"?verb=ListRecords&resumptionToken=oai_dc,inv/1,2018-07-01T00:00:00Z,2018-07-15T00:00:00Z,null");
 
 		getXmlNode(response, "ListRecords");
 		getXmlNodes(response, "record", 1);
@@ -504,5 +530,26 @@ public class TestVerbs extends BaseTest {
 		NamedNodeMap attributes = error.getAttributes();
 		Node errorCode = attributes.getNamedItem("code");
 		assertEquals("badArgument", errorCode.getTextContent());
+	}
+
+	@Test
+	public void testListRecordsWithSet() throws Exception {
+		Document response = request("?verb=ListRecords&metadataPrefix=oai_dc&set=exampleSetA");
+
+		getXmlNode(response, "ListRecords");
+		getXmlNodes(response, "record", 2);
+
+		String resumptionToken = getXmlNode(response, "resumptionToken").getTextContent();
+		assertEquals("", resumptionToken);
+	}
+
+	@Test
+	public void testListRecordsWithUndefinedSet() throws Exception {
+		Document response = request("?verb=ListRecords&metadataPrefix=oai_dc&set=undefined");
+
+		Node error = getXmlNode(response, "error");
+		NamedNodeMap attributes = error.getAttributes();
+		Node errorCode = attributes.getNamedItem("code");
+		assertEquals("noRecordsMatch", errorCode.getTextContent());
 	}
 }

--- a/src/test/java/org/icatproject/icat_oaipmh/integration/TestVerbs.java
+++ b/src/test/java/org/icatproject/icat_oaipmh/integration/TestVerbs.java
@@ -219,7 +219,7 @@ public class TestVerbs extends BaseTest {
 		assertEquals(investigationUniqueIdentifier, identifier);
 
 		Node setSpec = getXmlNode(response, "setSpec");
-		assertEquals("exampleSetB", setSpec.getTextContent());
+		assertEquals("exampleSetC", setSpec.getTextContent());
 	}
 
 	@Test
@@ -232,7 +232,8 @@ public class TestVerbs extends BaseTest {
 		String identifier = getXmlChild(header, "identifier").getTextContent();
 		assertEquals(studyUniqueIdentifier, identifier);
 
-		getXmlNodes(response, "setSpec", 0);
+		Node setSpec = getXmlNode(response, "setSpec");
+		assertEquals("exampleSetB", setSpec.getTextContent());
 	}
 
 	@Test

--- a/src/test/java/org/icatproject/icat_oaipmh/integration/TestVerbs.java
+++ b/src/test/java/org/icatproject/icat_oaipmh/integration/TestVerbs.java
@@ -147,9 +147,8 @@ public class TestVerbs extends BaseTest {
 
 	@Test
 	public void testListMetadataFormatsStudy() throws Exception {
-		Document response = null;
+		Document response = request("?verb=ListMetadataFormats&identifier=" + studyUniqueIdentifier);
 
-		response = request("?verb=ListMetadataFormats&identifier=" + studyUniqueIdentifier);
 		getXmlNode(response, "ListMetadataFormats");
 
 		Node metadataFormat = getXmlNode(response, "metadataFormat");
@@ -164,6 +163,30 @@ public class TestVerbs extends BaseTest {
 		NamedNodeMap attributes = error.getAttributes();
 		Node errorCode = attributes.getNamedItem("code");
 		assertEquals("idDoesNotExist", errorCode.getTextContent());
+	}
+
+	@Test
+	public void testListSets() throws Exception {
+		Document response = request("?verb=ListSets");
+
+		Node listSets = getXmlNode(response, "ListSets");
+		List<Node> sets = getXmlChildren(listSets, "set");
+
+		assertEquals(3, sets.size());
+
+		for (Node set : sets) {
+			String setSpec = getXmlChild(set, "setSpec").getTextContent();
+			String setName = getXmlChild(set, "setName").getTextContent();
+
+			if (setSpec.equals("exampleSetA"))
+				assertEquals("Example Set A", setName);
+			else if (setSpec.equals("exampleSetB"))
+				assertEquals("Example Set B", setName);
+			else if (setSpec.equals("exampleSetC"))
+				assertEquals("Example Set C", setName);
+			else
+				throw new AssertionError("Unknown setSpec: " + setSpec);
+		}
 	}
 
 	@Test

--- a/src/test/resources/oaipmhInvStud.properties
+++ b/src/test/resources/oaipmhInvStud.properties
@@ -54,14 +54,19 @@ data.stud.studyInvestigations.investigation.investigationUsers.stringProperties 
 data.stud.studyInvestigations.investigation.investigationUsers.subPropertyLists = user
 data.stud.studyInvestigations.investigation.investigationUsers.user.stringProperties = fullName givenName familyName orcidId
 
-sets = exampleSetA exampleSetB
+sets = exampleSetA exampleSetB exampleSetC
 
 sets.exampleSetA.name = Example Set A
 sets.exampleSetB.name = Example Set B
+sets.exampleSetC.name = Example Set C
 
 sets.exampleSetA.configurations = inv stud
-sets.exampleSetB.configurations = inv
+sets.exampleSetB.configurations = inv stud
+sets.exampleSetC.configurations = inv
 
 sets.exampleSetA.condition.inv = a.modTime >= '2018-07-20 08:00:00' AND a.modTime <= '2018-07-30 08:00:00'
 sets.exampleSetA.condition.stud = a.modTime <= '2018-07-20 10:00:00'
+
+sets.exampleSetB.condition.inv = b.name = 'Nickel' OR b.name = 'Ni'
+sets.exampleSetB.condition.stud = e.name = 'Nickel' OR e.name = 'Ni'
 

--- a/src/test/resources/oaipmhInvStud.properties
+++ b/src/test/resources/oaipmhInvStud.properties
@@ -66,7 +66,9 @@ sets.exampleSetC.configurations = inv
 
 sets.exampleSetA.condition.inv = a.modTime >= '2018-07-20 08:00:00' AND a.modTime <= '2018-07-30 08:00:00'
 sets.exampleSetA.condition.stud = a.modTime <= '2018-07-20 10:00:00'
+sets.exampleSetB.condition.inv = kw.name = 'Nickel' OR kw.name = 'Ni'
+sets.exampleSetB.condition.stud = kw.name = 'Nickel' OR kw.name = 'Ni'
 
-sets.exampleSetB.condition.inv = b.name = 'Nickel' OR b.name = 'Ni'
-sets.exampleSetB.condition.stud = e.name = 'Nickel' OR e.name = 'Ni'
+sets.exampleSetB.join.inv = JOIN a.keywords AS kw
+sets.exampleSetB.join.stud = JOIN a.studyInvestigations AS si JOIN si.investigation AS i JOIN i.keywords AS kw
 

--- a/src/test/resources/oaipmhInvStud.properties
+++ b/src/test/resources/oaipmhInvStud.properties
@@ -54,3 +54,14 @@ data.stud.studyInvestigations.investigation.investigationUsers.stringProperties 
 data.stud.studyInvestigations.investigation.investigationUsers.subPropertyLists = user
 data.stud.studyInvestigations.investigation.investigationUsers.user.stringProperties = fullName givenName familyName orcidId
 
+sets = exampleSetA exampleSetB
+
+sets.exampleSetA.name = Example Set A
+sets.exampleSetB.name = Example Set B
+
+sets.exampleSetA.configurations = inv stud
+sets.exampleSetB.configurations = inv
+
+sets.exampleSetA.condition.inv = a.modTime >= '2018-07-20 08:00:00' AND a.modTime <= '2018-07-30 08:00:00'
+sets.exampleSetA.condition.stud = a.modTime <= '2018-07-20 10:00:00'
+


### PR DESCRIPTION
This PR adds support for sets as elaborated in #7.

The implementation is based on the `run.properties` configuration file. It adds several optional new configuration properties `sets.*` that can be used to set up the individual sets in the repository. In principle, there is no limit to the number of sets you can configure. Each set must have an identifier and a name:

```properties
sets = exampleSetA exampleSetB exampleSetC

sets.exampleSetA.name = Example Set A
sets.exampleSetB.name = Example Set B
sets.exampleSetC.name = Example Set C
```

In its most basic form, a set may be configured to include _all_ items from a particular data configuration, e.g. all Investigations. In this case, no further conditions are applied, thus all Investigations in the repository would be affiliated with the set.

```properties
# The set shall consist only of Investigations, and there are no further conditions
sets.exampleSetC.configurations = inv
```

If the set shall include only _some_ items from a data configuration, you can specify a condition using JPQL syntax. Only items that meet this condition will be affiliated with the set. For each data configuration that is part of the set, one such condition may be configured.

```properties
# The set shall consist of both Investigations and Studies
sets.exampleSetA.configurations = inv stud

# Investigations shall only be affiliated with the set if they were modified between 2018-07-20 and 2018-07-30 
sets.exampleSetA.condition.inv = a.modTime >= '2018-07-20 08:00:00' AND a.modTime <= '2018-07-30 08:00:00'

# Studies shall only be affiliated with the set if they were modified before 2018-07-20
sets.exampleSetA.condition.stud = a.modTime <= '2018-07-20 10:00:00'
```

To allow more sophisticated conditions, you can also configure a list of data objects that shall be JOINed when retrieving the items of a set. This enables conditions to refer also to related objects.

```properties
# The set shall consist of both Investigations and Studies
sets.exampleSetB.configurations = inv stud

# JOIN related Keywords and make them accessible in the query as entity variable 'kw'
sets.exampleSetB.join.inv = JOIN a.keywords AS kw
sets.exampleSetB.join.stud = JOIN a.studyInvestigations AS si JOIN si.investigation AS i JOIN i.keywords AS kw

# Only Studies and Investigations related to a Keyword named 'Nickel' or 'Ni' shall be affiliated with the set 
sets.exampleSetB.condition.inv = kw.name = 'Nickel' OR kw.name = 'Ni'
sets.exampleSetB.condition.stud = kw.name = 'Nickel' OR kw.name = 'Ni'
```

In theory, this should provide enough flexibility for all kinds of scenarios, including harvestation by OpenAIRE. Once this PR is merged we can therefore close #7.