### PR TITLE
Take the absence of the sets property gracefully

### DIFF
--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -195,13 +195,17 @@ public class ResponseBuilder {
     }
 
     public void buildListSetsResponse(HttpServletRequest req, XmlResponse res) throws InternalException {
-        Element listSets = res.addXmlElement(null, "ListSets");
+        if (sets.isEmpty()) {
+            res.addError("noSetHierarchy", "This repository does not have any sets");
+        } else {
+            Element listSets = res.addXmlElement(null, "ListSets");
 
-        for (Map.Entry<String, ItemSet> s : sets.entrySet()) {
-            Element set = res.addXmlElement(listSets, "set");
+            for (Map.Entry<String, ItemSet> s : sets.entrySet()) {
+                Element set = res.addXmlElement(listSets, "set");
 
-            res.addXmlElement(set, "setSpec", s.getKey());
-            res.addXmlElement(set, "setName", s.getValue().getSetName());
+                res.addXmlElement(set, "setSpec", s.getKey());
+                res.addXmlElement(set, "setName", s.getValue().getSetName());
+            }
         }
     }
 

--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -23,7 +23,10 @@ if arg == "INSTALL":
 
     metadataPrefixes = properties["metadataPrefixes"].split()
     dataConfigurations = properties["data.configurations"].split()
-    sets = properties["sets"].split()
+    try:
+        sets = properties["sets"].split()
+    except KeyError:
+        sets = []
 
     try:
         val = int(properties["maxResults"])


### PR DESCRIPTION
It seems that `icat.oaipmh` indeed works fine with the sets property not set.  So we can fix #9 by modifying `setup` to take its absence gracefully.