### PR TITLE
Amend documentation and example value for responseStyle property

### DIFF
--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -105,5 +105,6 @@
 # If set to 'true', metadata won't be transformed into another format
 !responseDebug = true
 
-# The URL to an XSL document to be applied to all XML responses
-!responseStyle = https://oai.datacite.org/xsl/oaitohtml.xsl
+# The URL to an XSLT document to be applied to all XML responses.
+# Must be hosted on the same server as icat.oaipmh.
+!responseStyle = /static/oaitohtml.xsl

--- a/src/site/xhtml/installation.xhtml.vm
+++ b/src/site/xhtml/installation.xhtml.vm
@@ -495,13 +495,17 @@
 		</dd>
 		<dt>responseStyle</dt>
 		<dd>
-			Set this (optional) parameter to the URL of an XSL document which
-			you want to apply to all XML responses.
+			Set this (optional) parameter to the URL of an XSLT document which
+			you want to apply to all XML responses.  The browser's same-origin
+			policy requires this file to be hosted on the same server as
+			icat.oaipmh.
 		</dd>
 		<dd>
 			One particular use case for this would be to have the XML responses
 			transform into HTML documents when making OAI-PMH calls from a web
-			browser.
+			browser.  This is particularly useful for debugging.  A suitable
+			XSLT file for this purpose can be found
+			<a href="https://wiki.eprints.org/w/EPrints_OAI_Stylesheet">here</a>.
 		</dd>
 	</dl>
 


### PR DESCRIPTION
The example value for `responseStyle` in `run.properties.example` does not work any more.  The link to the file at DataCite is dead.  An externally hosted XLST file will not work (any more) anyway.  At least current versions of Firefox seem to refuse to apply that due to same-origin policy.  So it seems that this must be hosted on the same server.

I shortly considered to include a suitable XLST file as static content to the war file, so it could be conveniently linked.  But the EPrints XLST file that used to be found at the DataCite URL is GPL licensed which is incompatible to the Apache license we use, so we can't include it.  But of course, we may point to it in the documentation and the user is free to download and install it.