### PR TITLE
Fix query for earliest modTime in buildIdentifyResponse()

### DIFF
--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -110,7 +110,7 @@ public class ResponseBuilder {
         OffsetDateTime earliestDateTime = OffsetDateTime.MAX;
 
         for (DataConfiguration dataConfiguration : dataConfigurations.values()) {
-            String query = String.format("SELECT a.modTime FROM %s a ORDER BY a.modTime",
+            String query = String.format("SELECT MIN(a.modTime) FROM %s a",
                     dataConfiguration.getMainObject());
             String result = queryIcat(query);
             JsonReader jsonReader = Json.createReader(new StringReader(result));

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -13,6 +13,8 @@
 	<ul>
 		<li>#7, #8: Add support for the OAI-PMH Sets feature for the purpose of
 		selective harvesting.</li>
+		<li>#13, 14: Fix: identify fails with internal server error if many objects are
+		accessible.</li>
 		<li>Various fixes to ensure compatibility with OAI-PMH.</li>
 	</ul>
 


### PR DESCRIPTION
This fixes #13.

Looking into the sources, the problem becomes apparent: in order to get the earliest modification time `buildIdentifyResponse()` searches for `"SELECT a.modTime FROM %s a ORDER BY a.modTime"`. This fetches all the modification times, picks the first row from the result and throws away the rest. This is not only inefficient, but also fails if the result becomes too large.  Obviously, it's far better to search for the earliest modification time only: `"SELECT MIN(a.modTime) FROM %s a"`.