### PR TITLE
Fix query for collecting the IDs of items in a set

### DIFF
--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -390,6 +390,7 @@ public class ResponseBuilder {
                     join = setJoin != null ? setJoin : "";
                     where = setCondition != null ? String.format("WHERE %s", setCondition) : "";
 
+                    JsonArray setResultsArray;
                     ArrayList<String> setObjectIds = new ArrayList<String>();
                     do {
                         query = String.format("SELECT DISTINCT a.id FROM %s a %s %s LIMIT %s,%s", mainObject, join,
@@ -398,13 +399,13 @@ public class ResponseBuilder {
                         offsetResults += maxResults;
 
                         jsonReader = Json.createReader(new StringReader(result));
-                        resultsArray = jsonReader.readArray();
+                        setResultsArray = jsonReader.readArray();
                         jsonReader.close();
 
-                        for (JsonValue id : resultsArray) {
+                        for (JsonValue id : setResultsArray) {
                             setObjectIds.add(id.toString());
                         }
-                    } while (!resultsArray.isEmpty());
+                    } while (!setResultsArray.isEmpty());
                     setsObjectIds.put(set.getKey(), setObjectIds);
                 }
             }

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -358,7 +358,7 @@ public class ResponseBuilder {
             String join = setJoin != null ? setJoin : "";
             String includes = dataConfiguration.getIncludedObjects();
             String where = parameters.makeWhereCondition(dataConfigurationIdentifier, setCondition);
-            Integer queryLimit = new Integer(remainingResults + 1);
+            Integer queryLimit = Integer.valueOf(remainingResults + 1);
             String query = String.format("SELECT DISTINCT a FROM %s a %s %s ORDER BY a.id LIMIT 0,%s %s", mainObject,
                     join, where, queryLimit, includes);
 
@@ -379,6 +379,9 @@ public class ResponseBuilder {
             if (incomplete && remainingResults <= 0)
                 break;
 
+            // for each set, get the IDs of the affiliated items
+            Integer offsetResults = Integer.valueOf(0);
+            Integer maxResults = Integer.valueOf(parameters.getMaxResults());
             HashMap<String, ArrayList<String>> setsObjectIds = new HashMap<String, ArrayList<String>>();
             for (Map.Entry<String, ItemSet> set : sets.entrySet()) {
                 setCondition = set.getValue().getDataConfigurationsConditions().get(dataConfigurationIdentifier);
@@ -386,17 +389,22 @@ public class ResponseBuilder {
                 if (setCondition != null || setJoin != null) {
                     join = setJoin != null ? setJoin : "";
                     where = setCondition != null ? String.format("WHERE %s", setCondition) : "";
-                    query = String.format("SELECT DISTINCT a.id FROM %s a %s %s", mainObject, join, where);
-                    result = queryIcat(query);
-
-                    JsonReader setJsonReader = Json.createReader(new StringReader(result));
-                    JsonArray setResultsArray = setJsonReader.readArray();
-                    setJsonReader.close();
 
                     ArrayList<String> setObjectIds = new ArrayList<String>();
-                    for (JsonValue id : setResultsArray) {
-                        setObjectIds.add(id.toString());
-                    }
+                    do {
+                        query = String.format("SELECT DISTINCT a.id FROM %s a %s %s LIMIT %s,%s", mainObject, join,
+                                where, offsetResults, maxResults);
+                        result = queryIcat(query);
+                        offsetResults += maxResults;
+
+                        jsonReader = Json.createReader(new StringReader(result));
+                        resultsArray = jsonReader.readArray();
+                        jsonReader.close();
+
+                        for (JsonValue id : resultsArray) {
+                            setObjectIds.add(id.toString());
+                        }
+                    } while (!resultsArray.isEmpty());
                     setsObjectIds.put(set.getKey(), setObjectIds);
                 }
             }

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -380,7 +380,6 @@ public class ResponseBuilder {
                 break;
 
             // for each set, get the IDs of the affiliated items
-            Integer offsetResults = Integer.valueOf(0);
             Integer maxResults = Integer.valueOf(parameters.getMaxResults());
             HashMap<String, ArrayList<String>> setsObjectIds = new HashMap<String, ArrayList<String>>();
             for (Map.Entry<String, ItemSet> set : sets.entrySet()) {
@@ -391,6 +390,7 @@ public class ResponseBuilder {
                     where = setCondition != null ? String.format("WHERE %s", setCondition) : "";
 
                     JsonArray setResultsArray;
+                    Integer offsetResults = Integer.valueOf(0);
                     ArrayList<String> setObjectIds = new ArrayList<String>();
                     do {
                         query = String.format("SELECT DISTINCT a.id FROM %s a %s %s LIMIT %s,%s", mainObject, join,


### PR DESCRIPTION
This accompanies #14. It fixes an issue where the query that collects the IDs of all items related to a particular set fails if the result becomes too large.

There are two things to note:
1. I haven't tested this yet.
2. The provided fix collects the IDs in multiple iterations, using LIMIT clauses to make sure the result doesn't become too large. For the moment, I'm using the configured `maxResults` property as LIMIT. This is simple and straightforward, but it's a bit unintuitive and might not be the best approach.