### PR TITLE
Fix performance with sets

### DIFF
--- a/src/main/java/org/icatproject/icat_oaipmh/ICATInterface.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ICATInterface.java
@@ -1,0 +1,48 @@
+package org.icatproject.icat_oaipmh;
+
+import java.io.StringReader;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.icatproject.icat.client.ICAT;
+import org.icatproject.icat.client.IcatException;
+import org.icatproject.icat.client.Session;
+
+public class ICATInterface {
+
+    private ICAT icat;
+    private Session icatSession;
+    private Integer icatMaxEntities;
+
+    public ICATInterface(String icatUrl) throws URISyntaxException, IcatException {
+        icat = new ICAT(icatUrl);
+
+        String icatPropertiesString = icat.getProperties();
+        JsonReader jsonReader = Json.createReader(new StringReader(icatPropertiesString));
+        JsonObject icatProperties = jsonReader.readObject();
+        jsonReader.close();
+
+        icatMaxEntities = Integer.valueOf(icatProperties.getInt("maxEntities"));
+    }
+
+    public void login(String[] icatAuth) throws IcatException {
+        HashMap<String, String> credentials = new HashMap<String, String>();
+        for (int i = 1; i < icatAuth.length; i += 2) {
+            credentials.put(icatAuth[i], icatAuth[i + 1]);
+        }
+
+        icatSession = icat.login(icatAuth[0], credentials);
+    }
+
+    public Session getIcatSession() {
+        return icatSession;
+    }
+
+    public Integer getIcatMaxEntities() {
+        return icatMaxEntities;
+    }
+}

--- a/src/main/java/org/icatproject/icat_oaipmh/RequestHandler.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/RequestHandler.java
@@ -144,7 +144,7 @@ public class RequestHandler {
     private String handleIllegalVerb(HttpServletRequest req, XmlResponse res, Templates template)
             throws InternalException {
         res.makeResponseOutline(rb.getRequestUrl(), new HashMap<String, String>(), responseStyle);
-        res.addError("badVerb", "Illegal verb: " + req.getParameter("verb"));
+        res.addError("badVerb", "Illegal verb");
         return res.transformXml(template);
     }
 

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -18,7 +18,6 @@ import javax.json.JsonValue;
 import javax.json.JsonValue.ValueType;
 import javax.servlet.http.HttpServletRequest;
 
-import org.icatproject.icat.client.ICAT;
 import org.icatproject.icat.client.IcatException;
 import org.icatproject.icat.client.IcatException.IcatExceptionType;
 import org.icatproject.icat.client.Session;
@@ -31,8 +30,7 @@ public class ResponseBuilder {
 
     private static final Logger logger = LoggerFactory.getLogger(ResponseBuilder.class);
 
-    private Session icatSession;
-    private final String icatUrl;
+    private ICATInterface restIcat;
     private final String[] icatAuth;
     private final String repositoryName;
     private final ArrayList<String> adminEmails;
@@ -42,15 +40,21 @@ public class ResponseBuilder {
     private HashMap<String, ItemSet> sets;
 
     public ResponseBuilder(String icatUrl, String[] icatAuth, String repositoryName, ArrayList<String> adminEmails,
-            String requestUrl) {
+            String requestUrl) throws InternalException {
         metadataFormats = new HashMap<String, MetadataFormat>();
         dataConfigurations = new HashMap<String, DataConfiguration>();
         sets = new HashMap<String, ItemSet>();
-        this.icatUrl = icatUrl;
         this.icatAuth = icatAuth;
         this.repositoryName = repositoryName;
         this.adminEmails = adminEmails;
         this.requestUrl = requestUrl;
+
+        try {
+            this.restIcat = new ICATInterface(icatUrl);
+        } catch (URISyntaxException | IcatException e) {
+            logger.error(e.getMessage());
+            throw new InternalException();
+        }
     }
 
     public void addMetadataFormat(String identifier, MetadataFormat metadataFormat) {
@@ -70,21 +74,8 @@ public class ResponseBuilder {
     }
 
     public void loginIcat() throws InternalException {
-        ICAT restIcat = null;
         try {
-            restIcat = new ICAT(icatUrl);
-        } catch (URISyntaxException e) {
-            logger.error(e.getMessage());
-            throw new InternalException();
-        }
-
-        HashMap<String, String> credentials = new HashMap<String, String>();
-        for (int i = 1; i < icatAuth.length; i += 2) {
-            credentials.put(icatAuth[i], icatAuth[i + 1]);
-        }
-
-        try {
-            icatSession = restIcat.login(icatAuth[0], credentials);
+            restIcat.login(icatAuth);
         } catch (IcatException e) {
             logger.error(e.getMessage());
             throw new InternalException();
@@ -93,6 +84,7 @@ public class ResponseBuilder {
 
     public String queryIcat(String query) throws InternalException {
         try {
+            Session icatSession = restIcat.getIcatSession();
             return icatSession.search(query);
         } catch (IcatException e) {
             if (e.getType().equals(IcatExceptionType.SESSION)) {
@@ -275,9 +267,7 @@ public class ResponseBuilder {
         if (resumptionToken != null) {
             try {
                 parameters = new IcatQueryParameters(resumptionToken, dataConfigurations.keySet());
-            } catch (DateTimeException | IllegalArgumentException e) {
-                res.addError("badArgument", "The request includes arguments with illegal values or syntax");
-            } catch (ParseException e) {
+            } catch (DateTimeException | IllegalArgumentException | ParseException e) {
                 res.addError("badResumptionToken", "The value of the resumptionToken argument is invalid");
             }
         } else {
@@ -380,7 +370,7 @@ public class ResponseBuilder {
                 break;
 
             // for each set, get the IDs of the affiliated items
-            Integer maxResults = Integer.valueOf(parameters.getMaxResults());
+            Integer icatMaxEntities = restIcat.getIcatMaxEntities();
             HashMap<String, ArrayList<String>> setsObjectIds = new HashMap<String, ArrayList<String>>();
             for (Map.Entry<String, ItemSet> set : sets.entrySet()) {
                 setCondition = set.getValue().getDataConfigurationsConditions().get(dataConfigurationIdentifier);
@@ -390,13 +380,13 @@ public class ResponseBuilder {
                     where = setCondition != null ? String.format("WHERE %s", setCondition) : "";
 
                     JsonArray setResultsArray;
-                    Integer offsetResults = Integer.valueOf(0);
+                    Integer offset = Integer.valueOf(0);
                     ArrayList<String> setObjectIds = new ArrayList<String>();
                     do {
                         query = String.format("SELECT DISTINCT a.id FROM %s a %s %s LIMIT %s,%s", mainObject, join,
-                                where, offsetResults, maxResults);
+                                where, offset, icatMaxEntities);
                         result = queryIcat(query);
-                        offsetResults += maxResults;
+                        offset += icatMaxEntities;
 
                         jsonReader = Json.createReader(new StringReader(result));
                         setResultsArray = jsonReader.readArray();

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -395,7 +395,7 @@ public class ResponseBuilder {
                         for (JsonValue id : setResultsArray) {
                             setObjectIds.add(id.toString());
                         }
-                    } while (!setResultsArray.isEmpty());
+                    } while (setResultsArray.size() == icatMaxEntities);
                     setsObjectIds.put(set.getKey(), setObjectIds);
                 }
             }

--- a/src/test/java/org/icatproject/icat_oaipmh/integration/TestVerbs.java
+++ b/src/test/java/org/icatproject/icat_oaipmh/integration/TestVerbs.java
@@ -292,7 +292,7 @@ public class TestVerbs extends BaseTest {
 	@Test
 	public void testListIdentifiersResumptionTokenAndAdditionalArguments() throws Exception {
 		Document response = request(
-				"?verb=ListIdentifiers&metadataPrefix=oai_dc&resumptionToken=oai_dc,inv/1,null,null,null");
+				"?verb=ListIdentifiers&metadataPrefix=oai_dc&resumptionToken=oai_dc,inv/0,null,null,null");
 
 		Node error = getXmlNode(response, "error");
 		NamedNodeMap attributes = error.getAttributes();
@@ -302,7 +302,7 @@ public class TestVerbs extends BaseTest {
 
 	@Test
 	public void testListIdentifiersInvalidResumptionTokenMetadataFormat() throws Exception {
-		Document response = request("?verb=ListIdentifiers&resumptionToken=invalid,inv/1,null,null,null");
+		Document response = request("?verb=ListIdentifiers&resumptionToken=invalid,inv/0,null,null,null");
 
 		Node error = getXmlNode(response, "error");
 		NamedNodeMap attributes = error.getAttributes();
@@ -451,7 +451,7 @@ public class TestVerbs extends BaseTest {
 	@Test
 	public void testListRecordsResumptionTokenAndAdditionalArguments() throws Exception {
 		Document response = request(
-				"?verb=ListRecords&metadataPrefix=oai_dc&resumptionToken=oai_dc,inv/1,null,null,null");
+				"?verb=ListRecords&metadataPrefix=oai_dc&resumptionToken=oai_dc,inv/0,null,null,null");
 
 		Node error = getXmlNode(response, "error");
 		NamedNodeMap attributes = error.getAttributes();
@@ -461,7 +461,7 @@ public class TestVerbs extends BaseTest {
 
 	@Test
 	public void testListRecordsInvalidResumptionTokenMetadataFormat() throws Exception {
-		Document response = request("?verb=ListRecords&resumptionToken=invalid,inv/1,null,null,null");
+		Document response = request("?verb=ListRecords&resumptionToken=invalid,inv/0,null,null,null");
 
 		Node error = getXmlNode(response, "error");
 		NamedNodeMap attributes = error.getAttributes();

--- a/src/test/java/org/icatproject/icat_oaipmh/integration/util/Setup.java
+++ b/src/test/java/org/icatproject/icat_oaipmh/integration/util/Setup.java
@@ -116,7 +116,7 @@ public class Setup {
 			for (JsonValue id : jsonArray) {
 				session.delete(String.format("{\"%s\":{\"id\":%s}}", object, id));
 			}
-		} while (!jsonArray.isEmpty());
+		} while (jsonArray.size() == maxEntities);
 	}
 
 	public String getRequestUrl() {


### PR DESCRIPTION
This fixes #16.

With the changes in this PR, icat.oaipmh new queries icat.server for the configured `maxEntities` value and use that in LIMIT clauses.

According to the findings in #16, this should bring up the performance with sets to an acceptable level.