### PR TITLE
Review exception handling and logging

### DIFF
--- a/src/main/java/org/icatproject/icat_oaipmh/IcatQueryParameters.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/IcatQueryParameters.java
@@ -1,6 +1,5 @@
 package org.icatproject.icat_oaipmh;
 
-import java.text.ParseException;
 import java.time.DateTimeException;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -9,10 +8,6 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Set;
-
-import org.icatproject.icat_oaipmh.exceptions.InternalException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class IcatQueryParameters {
 
@@ -32,10 +27,8 @@ public class IcatQueryParameters {
     private String identifierId;
     private String set;
 
-    private static final Logger logger = LoggerFactory.getLogger(XmlResponse.class);
-
     public IcatQueryParameters(String metadataPrefix, String from, String until, String set, String uniqueIdentifier,
-            Set<String> dataConfigurations) throws ParseException, InternalException {
+            Set<String> dataConfigurations) throws IllegalArgumentException, IllegalStateException, DateTimeException {
         this.metadataPrefix = metadataPrefix;
 
         this.lastDataConfiguration = null;
@@ -51,26 +44,26 @@ public class IcatQueryParameters {
             String[] identifierParts = uniqueIdentifier.split(":");
 
             if (identifierParts.length != 3)
-                throw new ParseException(uniqueIdentifier, 0);
+                throw new IllegalArgumentException();
 
             if (!identifierParts[0].equals("oai") || !identifierParts[1].equals(identifierPrefix))
-                throw new ParseException(uniqueIdentifier, 0);
+                throw new IllegalArgumentException();
 
             IcatQueryIdentifier identifier = parseIdentifier(identifierParts[2]);
             this.identifierDataConfiguration = identifier.getDataConfiguration();
             this.identifierId = identifier.getId();
 
             if (!dataConfigurations.contains(this.identifierDataConfiguration))
-                throw new ParseException(uniqueIdentifier, 0);
+                throw new IllegalArgumentException();
         }
     }
 
     public IcatQueryParameters(String resumptionToken, Set<String> dataConfigurations)
-            throws ParseException, InternalException {
+            throws IllegalArgumentException, IllegalStateException, DateTimeException {
         String[] token = resumptionToken.split(",");
 
         if (token.length != 5)
-            throw new ParseException(resumptionToken, 0);
+            throw new IllegalArgumentException();
 
         this.metadataPrefix = token[0];
 
@@ -79,7 +72,7 @@ public class IcatQueryParameters {
         this.lastId = last.getId();
 
         if (!dataConfigurations.contains(this.lastDataConfiguration))
-            throw new ParseException(resumptionToken, 0);
+            throw new IllegalArgumentException();
 
         this.from = token[2].equals("null") ? null : token[2];
         this.until = token[3].equals("null") ? null : token[3];
@@ -91,7 +84,7 @@ public class IcatQueryParameters {
         this.identifierId = null;
     }
 
-    private void setFromUntilTimes() throws InternalException {
+    private void setFromUntilTimes() throws IllegalStateException, DateTimeException {
         DateTimeFormatter dtf = null;
         OffsetDateTime dtFrom = null;
         OffsetDateTime dtUntil = null;
@@ -99,8 +92,7 @@ public class IcatQueryParameters {
         try {
             dtf = DateTimeFormatter.ofPattern(icatDateTimeFormat).withZone(ZoneId.of(icatDateTimeZone));
         } catch (IllegalArgumentException | DateTimeException e) {
-            logger.error(e.getMessage());
-            throw new InternalException();
+            throw new IllegalStateException(e.getMessage(), e.getCause());
         }
 
         if (this.from != null) {
@@ -123,7 +115,7 @@ public class IcatQueryParameters {
 
         if (dtFrom != null && dtUntil != null) {
             if (dtFrom.compareTo(dtUntil) > 0) {
-                throw new IllegalArgumentException();
+                throw new DateTimeException("from > until");
             }
 
             int testCount = 0;
@@ -139,18 +131,18 @@ public class IcatQueryParameters {
                 testCount++;
             }
             if (testCount % 2 != 0) {
-                throw new IllegalArgumentException();
+                throw new DateTimeException("format mismatch");
             }
         }
     }
 
-    private IcatQueryIdentifier parseIdentifier(String identifier) throws ParseException {
+    private IcatQueryIdentifier parseIdentifier(String identifier) throws IllegalArgumentException {
         String[] identifierItemPart = identifier.split("/");
 
         try {
             return new IcatQueryIdentifier(identifierItemPart[0], identifierItemPart[1]);
         } catch (IndexOutOfBoundsException e) {
-            throw new ParseException(identifier, 0);
+            throw new IllegalArgumentException();
         }
     }
 

--- a/src/main/java/org/icatproject/icat_oaipmh/IcatQueryParameters.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/IcatQueryParameters.java
@@ -173,13 +173,13 @@ public class IcatQueryParameters {
         return String.format("oai:%s:%s/%s", identifierPrefix, dataConfiguration, id);
     }
 
-    public static String makeFormattedDateTime(String dateTime) {
+    public static String makeFormattedDateTime(String dateTime) throws DateTimeException {
         if (dateTime != null)
             return formatDateTime(OffsetDateTime.parse(dateTime));
         return null;
     }
 
-    private static String formatDateTime(OffsetDateTime dateTime) {
+    private static String formatDateTime(OffsetDateTime dateTime) throws DateTimeException {
         return dateTime.format(DateTimeFormatter.ISO_INSTANT);
     }
 

--- a/src/main/java/org/icatproject/icat_oaipmh/RequestHandler.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/RequestHandler.java
@@ -63,17 +63,17 @@ public class RequestHandler {
         else {
             String verb = verbs[0];
             if (verb.equals("Identify"))
-                handleIdentify(req, res, template);
+                handleIdentify(req, res);
             else if (verb.equals("ListIdentifiers"))
-                handleListIdentifiers(req, res, template);
+                template = handleListIdentifiers(req, res);
             else if (verb.equals("ListRecords"))
-                handleListRecords(req, res, template);
+                template = handleListRecords(req, res);
             else if (verb.equals("ListSets"))
-                handleListSets(req, res, template);
+                handleListSets(req, res);
             else if (verb.equals("ListMetadataFormats"))
-                handleListMetadataFormats(req, res, template);
+                handleListMetadataFormats(req, res);
             else if (verb.equals("GetRecord"))
-                handleGetRecord(req, res, template);
+                template = handleGetRecord(req, res);
             else
                 handleIllegalVerb(req, res, String.format("Illegal verb: %s", verb));
         }
@@ -86,7 +86,7 @@ public class RequestHandler {
         }
     }
 
-    private void handleIdentify(HttpServletRequest req, XmlResponse res, Templates template) throws InternalException {
+    private void handleIdentify(HttpServletRequest req, XmlResponse res) throws InternalException {
         String[] allowedParameters = { "verb" };
         String[] requiredParameters = {};
 
@@ -95,31 +95,33 @@ public class RequestHandler {
         }
     }
 
-    private void handleListIdentifiers(HttpServletRequest req, XmlResponse res, Templates template)
-            throws InternalException {
+    private Templates handleListIdentifiers(HttpServletRequest req, XmlResponse res) throws InternalException {
         String[] allowedParameters = { "verb", "from", "until", "metadataPrefix", "set", "resumptionToken" };
         String[] requiredParameters = { "metadataPrefix" };
 
+        Templates template = null;
         if (checkParameters(allowedParameters, requiredParameters, req, res)) {
             template = getMetadataTemplate(req, res);
             if (template != null || responseDebug)
                 rb.buildListIdentifiersResponse(req, res);
         }
+        return template;
     }
 
-    private void handleListRecords(HttpServletRequest req, XmlResponse res, Templates template)
-            throws InternalException {
+    private Templates handleListRecords(HttpServletRequest req, XmlResponse res) throws InternalException {
         String[] allowedParameters = { "verb", "from", "until", "set", "resumptionToken", "metadataPrefix" };
         String[] requiredParameters = { "metadataPrefix" };
 
+        Templates template = null;
         if (checkParameters(allowedParameters, requiredParameters, req, res)) {
             template = getMetadataTemplate(req, res);
             if (template != null || responseDebug)
                 rb.buildListRecordsResponse(req, res);
         }
+        return template;
     }
 
-    private void handleListSets(HttpServletRequest req, XmlResponse res, Templates template) throws InternalException {
+    private void handleListSets(HttpServletRequest req, XmlResponse res) throws InternalException {
         String[] allowedParameters = { "verb" };
         String[] requiredParameters = {};
 
@@ -128,8 +130,7 @@ public class RequestHandler {
         }
     }
 
-    private void handleListMetadataFormats(HttpServletRequest req, XmlResponse res, Templates template)
-            throws InternalException {
+    private void handleListMetadataFormats(HttpServletRequest req, XmlResponse res) throws InternalException {
         String[] allowedParameters = { "verb", "identifier" };
         String[] requiredParameters = {};
 
@@ -138,15 +139,17 @@ public class RequestHandler {
         }
     }
 
-    private void handleGetRecord(HttpServletRequest req, XmlResponse res, Templates template) throws InternalException {
+    private Templates handleGetRecord(HttpServletRequest req, XmlResponse res) throws InternalException {
         String[] allowedParameters = { "verb", "identifier", "metadataPrefix" };
         String[] requiredParameters = { "identifier", "metadataPrefix" };
 
+        Templates template = null;
         if (checkParameters(allowedParameters, requiredParameters, req, res)) {
             template = getMetadataTemplate(req, res);
             if (template != null || responseDebug)
                 rb.buildGetRecordResponse(req, res);
         }
+        return template;
     }
 
     private void handleIllegalVerb(HttpServletRequest req, XmlResponse res, String message) throws InternalException {

--- a/src/main/java/org/icatproject/icat_oaipmh/RequestHandler.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/RequestHandler.java
@@ -9,8 +9,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.xml.transform.Templates;
 
 import org.icatproject.icat_oaipmh.exceptions.InternalException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RequestHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
     private ResponseBuilder rb;
 
@@ -41,29 +45,48 @@ public class RequestHandler {
     }
 
     public String request(HttpServletRequest req) throws InternalException {
-        XmlResponse res = new XmlResponse();
-        String[] verbs = req.getParameterValues("verb");
         Templates template = null;
+        XmlResponse res = null;
 
-        if (verbs != null && verbs.length == 1) {
+        try {
+            res = new XmlResponse();
+        } catch (IllegalStateException e) {
+            logger.error(e.getMessage());
+            throw new InternalException();
+        }
+        String[] verbs = req.getParameterValues("verb");
+
+        if (verbs == null)
+            handleIllegalVerb(req, res, "Missing verb argument");
+        else if (verbs.length > 1)
+            handleIllegalVerb(req, res, "Multiple verb arguments");
+        else {
             String verb = verbs[0];
             if (verb.equals("Identify"))
-                return handleIdentify(req, res, template);
-            if (verb.equals("ListIdentifiers"))
-                return handleListIdentifiers(req, res, template);
-            if (verb.equals("ListRecords"))
-                return handleListRecords(req, res, template);
-            if (verb.equals("ListSets"))
-                return handleListSets(req, res, template);
-            if (verb.equals("ListMetadataFormats"))
-                return handleListMetadataFormats(req, res, template);
-            if (verb.equals("GetRecord"))
-                return handleGetRecord(req, res, template);
+                handleIdentify(req, res, template);
+            else if (verb.equals("ListIdentifiers"))
+                handleListIdentifiers(req, res, template);
+            else if (verb.equals("ListRecords"))
+                handleListRecords(req, res, template);
+            else if (verb.equals("ListSets"))
+                handleListSets(req, res, template);
+            else if (verb.equals("ListMetadataFormats"))
+                handleListMetadataFormats(req, res, template);
+            else if (verb.equals("GetRecord"))
+                handleGetRecord(req, res, template);
+            else
+                handleIllegalVerb(req, res, String.format("Illegal verb: %s", verb));
         }
-        return handleIllegalVerb(req, res, template);
+
+        try {
+            return res.transformXml(template);
+        } catch (IllegalStateException e) {
+            logger.error(e.getMessage());
+            throw new InternalException();
+        }
     }
 
-    private String handleIdentify(HttpServletRequest req, XmlResponse res, Templates template)
+    private void handleIdentify(HttpServletRequest req, XmlResponse res, Templates template)
             throws InternalException {
         String[] allowedParameters = { "verb" };
         String[] requiredParameters = {};
@@ -71,11 +94,9 @@ public class RequestHandler {
         if (checkParameters(allowedParameters, requiredParameters, req, res)) {
             rb.buildIdentifyResponse(req, res);
         }
-
-        return res.transformXml(template);
     }
 
-    private String handleListIdentifiers(HttpServletRequest req, XmlResponse res, Templates template)
+    private void handleListIdentifiers(HttpServletRequest req, XmlResponse res, Templates template)
             throws InternalException {
         String[] allowedParameters = { "verb", "from", "until", "metadataPrefix", "set", "resumptionToken" };
         String[] requiredParameters = { "metadataPrefix" };
@@ -85,11 +106,9 @@ public class RequestHandler {
             if (template != null || responseDebug)
                 rb.buildListIdentifiersResponse(req, res);
         }
-
-        return res.transformXml(template);
     }
 
-    private String handleListRecords(HttpServletRequest req, XmlResponse res, Templates template)
+    private void handleListRecords(HttpServletRequest req, XmlResponse res, Templates template)
             throws InternalException {
         String[] allowedParameters = { "verb", "from", "until", "set", "resumptionToken", "metadataPrefix" };
         String[] requiredParameters = { "metadataPrefix" };
@@ -99,11 +118,9 @@ public class RequestHandler {
             if (template != null || responseDebug)
                 rb.buildListRecordsResponse(req, res);
         }
-
-        return res.transformXml(template);
     }
 
-    private String handleListSets(HttpServletRequest req, XmlResponse res, Templates template)
+    private void handleListSets(HttpServletRequest req, XmlResponse res, Templates template)
             throws InternalException {
         String[] allowedParameters = { "verb" };
         String[] requiredParameters = {};
@@ -111,11 +128,9 @@ public class RequestHandler {
         if (checkParameters(allowedParameters, requiredParameters, req, res)) {
             rb.buildListSetsResponse(req, res);
         }
-
-        return res.transformXml(template);
     }
 
-    private String handleListMetadataFormats(HttpServletRequest req, XmlResponse res, Templates template)
+    private void handleListMetadataFormats(HttpServletRequest req, XmlResponse res, Templates template)
             throws InternalException {
         String[] allowedParameters = { "verb", "identifier" };
         String[] requiredParameters = {};
@@ -123,11 +138,9 @@ public class RequestHandler {
         if (checkParameters(allowedParameters, requiredParameters, req, res)) {
             rb.buildListMetadataFormatsResponse(req, res);
         }
-
-        return res.transformXml(template);
     }
 
-    private String handleGetRecord(HttpServletRequest req, XmlResponse res, Templates template)
+    private void handleGetRecord(HttpServletRequest req, XmlResponse res, Templates template)
             throws InternalException {
         String[] allowedParameters = { "verb", "identifier", "metadataPrefix" };
         String[] requiredParameters = { "identifier", "metadataPrefix" };
@@ -137,15 +150,12 @@ public class RequestHandler {
             if (template != null || responseDebug)
                 rb.buildGetRecordResponse(req, res);
         }
-
-        return res.transformXml(template);
     }
 
-    private String handleIllegalVerb(HttpServletRequest req, XmlResponse res, Templates template)
+    private void handleIllegalVerb(HttpServletRequest req, XmlResponse res, String message)
             throws InternalException {
         res.makeResponseOutline(rb.getRequestUrl(), new HashMap<String, String>(), responseStyle);
-        res.addError("badVerb", "Illegal verb");
-        return res.transformXml(template);
+        res.addError("badVerb", message);
     }
 
     private boolean checkParameters(String[] allowedParameters, String[] requiredParameters, HttpServletRequest req,

--- a/src/main/java/org/icatproject/icat_oaipmh/RequestHandler.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/RequestHandler.java
@@ -86,8 +86,7 @@ public class RequestHandler {
         }
     }
 
-    private void handleIdentify(HttpServletRequest req, XmlResponse res, Templates template)
-            throws InternalException {
+    private void handleIdentify(HttpServletRequest req, XmlResponse res, Templates template) throws InternalException {
         String[] allowedParameters = { "verb" };
         String[] requiredParameters = {};
 
@@ -120,8 +119,7 @@ public class RequestHandler {
         }
     }
 
-    private void handleListSets(HttpServletRequest req, XmlResponse res, Templates template)
-            throws InternalException {
+    private void handleListSets(HttpServletRequest req, XmlResponse res, Templates template) throws InternalException {
         String[] allowedParameters = { "verb" };
         String[] requiredParameters = {};
 
@@ -140,8 +138,7 @@ public class RequestHandler {
         }
     }
 
-    private void handleGetRecord(HttpServletRequest req, XmlResponse res, Templates template)
-            throws InternalException {
+    private void handleGetRecord(HttpServletRequest req, XmlResponse res, Templates template) throws InternalException {
         String[] allowedParameters = { "verb", "identifier", "metadataPrefix" };
         String[] requiredParameters = { "identifier", "metadataPrefix" };
 
@@ -152,8 +149,7 @@ public class RequestHandler {
         }
     }
 
-    private void handleIllegalVerb(HttpServletRequest req, XmlResponse res, String message)
-            throws InternalException {
+    private void handleIllegalVerb(HttpServletRequest req, XmlResponse res, String message) throws InternalException {
         res.makeResponseOutline(rb.getRequestUrl(), new HashMap<String, String>(), responseStyle);
         res.addError("badVerb", message);
     }

--- a/src/main/java/org/icatproject/icat_oaipmh/RequestInterface.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/RequestInterface.java
@@ -26,15 +26,12 @@ import org.icatproject.utils.CheckedProperties;
 import org.icatproject.utils.CheckedProperties.CheckedPropertyException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
 
 @Path("/")
 @Stateless
 public class RequestInterface {
 
 	private static final Logger logger = LoggerFactory.getLogger(RequestInterface.class);
-	private static final Marker fatal = MarkerFactory.getMarker("FATAL");
 
 	private static final String[] propertyTypes = { "stringProperties", "numericProperties", "dateProperties" };
 
@@ -133,8 +130,8 @@ public class RequestInterface {
 			}
 		} catch (CheckedPropertyException | FileNotFoundException | SecurityException | NumberFormatException
 				| TransformerConfigurationException | URISyntaxException e) {
-			logger.error(fatal, e.getMessage());
-			throw new IllegalStateException(e.getMessage());
+			logger.error(e.getMessage());
+			throw new IllegalStateException();
 		} catch (InternalException e) {
 			throw new IllegalStateException();
 		}

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -115,8 +115,8 @@ public class ResponseBuilder {
                     earliestDateTime = earliest;
                     earliestDatestamp = IcatQueryParameters.makeFormattedDateTime(earliestString);
                 }
-            } catch (IndexOutOfBoundsException e) {
-                logger.warn("No objects of type " + dataConfiguration.getMainObject() + " exist in ICAT");
+            } catch (IndexOutOfBoundsException | ClassCastException e) {
+                logger.warn("No objects of type " + dataConfiguration.getMainObject() + " found in ICAT");
             } catch (DateTimeException e) {
                 logger.error(e.getMessage());
                 throw new InternalException();

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -267,8 +267,11 @@ public class ResponseBuilder {
         if (resumptionToken != null) {
             try {
                 parameters = new IcatQueryParameters(resumptionToken, dataConfigurations.keySet());
-            } catch (DateTimeException | IllegalArgumentException | ParseException e) {
+            } catch (DateTimeException | IllegalArgumentException e) {
                 res.addError("badResumptionToken", "The value of the resumptionToken argument is invalid");
+            } catch (IllegalStateException e) {
+                logger.error(e.getMessage());
+                throw new InternalException();
             }
         } else {
             String metadataPrefix = req.getParameter("metadataPrefix");
@@ -279,11 +282,14 @@ public class ResponseBuilder {
             try {
                 parameters = new IcatQueryParameters(metadataPrefix, from, until, set, identifier,
                         dataConfigurations.keySet());
-            } catch (DateTimeException | IllegalArgumentException e) {
+            } catch (DateTimeException e) {
                 res.addError("badArgument", "The request includes arguments with illegal values or syntax");
-            } catch (ParseException e) {
+            } catch (IllegalArgumentException e) {
                 res.addError("idDoesNotExist",
                         "Identifier '" + identifier + "' is unknown or illegal in this repository");
+            } catch (IllegalStateException e) {
+                logger.error(e.getMessage());
+                throw new InternalException();
             }
         }
 

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -504,7 +504,11 @@ public class ResponseBuilder {
                     String value = ((JsonObject) element).getString(prop, null);
                     if (value != null) {
                         ArrayList<String> valueList = new ArrayList<String>();
-                        valueList.add(IcatQueryParameters.makeFormattedDateTime(value));
+                        try {
+                            valueList.add(IcatQueryParameters.makeFormattedDateTime(value));
+                        } catch (DateTimeException e) {
+                            logger.warn("Cannot format property " + prop + " as date");
+                        }
                         elementProperties.put(prop, valueList);
                     }
                 }
@@ -544,7 +548,11 @@ public class ResponseBuilder {
                 String value = jsonObject.getString(prop, null);
                 if (value != null) {
                     ArrayList<String> valueList = new ArrayList<String>();
-                    valueList.add(IcatQueryParameters.makeFormattedDateTime(value));
+                    try {
+                        valueList.add(IcatQueryParameters.makeFormattedDateTime(value));
+                    } catch (DateTimeException e) {
+                        logger.warn("Cannot format " + dataConfigurationIdentifier + " property " + prop + " as date");
+                    }
                     properties.put(prop, valueList);
                 }
             }

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -237,21 +237,19 @@ public class ResponseBuilder {
         IcatQueryParameters parameters = getIcatQueryParameters(req, res);
 
         if (parameters != null) {
+            IcatQueryResults result = getIcatRecords(parameters, true);
+
             String metadataPrefix = parameters.getMetadataPrefix();
             String dataConfigurationIdentifier = parameters.getIdentifierDataConfiguration();
             DataConfiguration dataConfiguration = dataConfigurations.get(dataConfigurationIdentifier);
 
-            if (!dataConfiguration.getMetadataPrefixes().contains(metadataPrefix)) {
+            if (result.getResults().isEmpty()) {
+                res.addError("idDoesNotExist",
+                        "Identifier '" + req.getParameter("identifier") + "' is unknown or illegal in this repository");
+            } else if (!dataConfiguration.getMetadataPrefixes().contains(metadataPrefix)) {
                 res.addError("cannotDisseminateFormat", "'" + metadataPrefix + "' is not supported by the item");
             } else {
-                IcatQueryResults result = getIcatRecords(parameters, true);
-
-                if (result.getResults().isEmpty()) {
-                    res.addError("idDoesNotExist", "Identifier '" + req.getParameter("identifier")
-                            + "' is unknown or illegal in this repository");
-                } else {
-                    res.addRecordInformation(result.getResults(), "GetRecord", true);
-                }
+                res.addRecordInformation(result.getResults(), "GetRecord", true);
             }
         }
     }

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -308,15 +308,17 @@ public class ResponseBuilder {
 
             // if the harvester requested a specific item,
             // skip data configurations which don't match with this item
-            if (parameters.getIdentifierDataConfiguration() != null)
+            if (parameters.getIdentifierDataConfiguration() != null) {
                 if (!parameters.getIdentifierDataConfiguration().equals(dataConfigurationIdentifier))
                     continue;
+            }
 
             // if the harvester requested a specific metadataPrefix,
             // skip data configurations which don't support this metadataPrefix
-            if (parameters.getMetadataPrefix() != null)
+            else if (parameters.getMetadataPrefix() != null) {
                 if (!dataConfiguration.getMetadataPrefixes().contains(parameters.getMetadataPrefix()))
                     continue;
+            }
 
             // if the harvester used a resumptionToken,
             // skip data configurations which come before the 'lastDataConfiguration'

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -205,33 +205,30 @@ public class ResponseBuilder {
         IcatQueryParameters parameters = getIcatQueryParameters(req, res);
 
         if (parameters != null) {
-            IcatQueryResults result = getIcatRecords(parameters, false);
+            DataConfiguration dataConfiguration = null;
             String dataConfigurationIdentifier = parameters.getIdentifierDataConfiguration();
 
-            if (dataConfigurationIdentifier != null && result.getResults().isEmpty()) {
-                res.addError("idDoesNotExist",
-                        "Identifier '" + req.getParameter("identifier") + "' is unknown or illegal in this repository");
-            } else {
-                boolean listAllMetadataFormats = true;
-                DataConfiguration dataConfiguration = null;
-
-                if (dataConfigurationIdentifier != null) {
-                    listAllMetadataFormats = false;
-                    dataConfiguration = dataConfigurations.get(dataConfigurationIdentifier);
+            if (dataConfigurationIdentifier != null) {
+                IcatQueryResults result = getIcatRecords(parameters, false);
+                if (result.getResults().isEmpty()) {
+                    res.addError("idDoesNotExist", "Identifier '" + req.getParameter("identifier")
+                            + "' is unknown or illegal in this repository");
+                    return;
                 }
+                dataConfiguration = dataConfigurations.get(dataConfigurationIdentifier);
+            }
 
-                Element listMetadataFormats = res.addXmlElement(null, "ListMetadataFormats");
+            Element listMetadataFormats = res.addXmlElement(null, "ListMetadataFormats");
 
-                for (Map.Entry<String, MetadataFormat> format : metadataFormats.entrySet()) {
-                    if (!listAllMetadataFormats && !dataConfiguration.getMetadataPrefixes().contains(format.getKey()))
-                        continue;
+            for (Map.Entry<String, MetadataFormat> format : metadataFormats.entrySet()) {
+                if (dataConfiguration != null && !dataConfiguration.getMetadataPrefixes().contains(format.getKey()))
+                    continue;
 
-                    Element metadataFormat = res.addXmlElement(listMetadataFormats, "metadataFormat");
+                Element metadataFormat = res.addXmlElement(listMetadataFormats, "metadataFormat");
 
-                    res.addXmlElement(metadataFormat, "metadataPrefix", format.getKey());
-                    res.addXmlElement(metadataFormat, "schema", format.getValue().getMetadataSchema());
-                    res.addXmlElement(metadataFormat, "metadataNamespace", format.getValue().getMetadataNamespace());
-                }
+                res.addXmlElement(metadataFormat, "metadataPrefix", format.getKey());
+                res.addXmlElement(metadataFormat, "schema", format.getValue().getMetadataSchema());
+                res.addXmlElement(metadataFormat, "metadataNamespace", format.getValue().getMetadataNamespace());
             }
         }
     }

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -2,7 +2,6 @@ package org.icatproject.icat_oaipmh;
 
 import java.io.StringReader;
 import java.net.URISyntaxException;
-import java.text.ParseException;
 import java.time.DateTimeException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -102,8 +101,7 @@ public class ResponseBuilder {
         OffsetDateTime earliestDateTime = OffsetDateTime.MAX;
 
         for (DataConfiguration dataConfiguration : dataConfigurations.values()) {
-            String query = String.format("SELECT MIN(a.modTime) FROM %s a",
-                    dataConfiguration.getMainObject());
+            String query = String.format("SELECT MIN(a.modTime) FROM %s a", dataConfiguration.getMainObject());
             String result = queryIcat(query);
             JsonReader jsonReader = Json.createReader(new StringReader(result));
             JsonArray jsonArray = jsonReader.readArray();
@@ -430,8 +428,7 @@ public class ResponseBuilder {
     }
 
     private XmlInformation extractHeaderInformation(JsonValue data, String dataConfigurationIdentifier,
-            RequestedProperties requestedProperties, Map<String, ? extends List<String>> setsObjectIds)
-            throws InternalException {
+            RequestedProperties requestedProperties, Map<String, ? extends List<String>> setsObjectIds) {
         HashMap<String, ArrayList<String>> properties = new HashMap<String, ArrayList<String>>();
 
         JsonObject icatObject = ((JsonObject) data).getJsonObject(requestedProperties.getIcatObject());
@@ -463,7 +460,7 @@ public class ResponseBuilder {
     }
 
     private ArrayList<XmlInformation> extractMetadataInformation(JsonValue data, String dataConfigurationIdentifier,
-            RequestedProperties requestedProperties) throws InternalException {
+            RequestedProperties requestedProperties) {
         ArrayList<XmlInformation> result = new ArrayList<XmlInformation>();
 
         HashMap<String, ArrayList<String>> properties = new HashMap<String, ArrayList<String>>();

--- a/src/main/java/org/icatproject/icat_oaipmh/XmlResponse.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/XmlResponse.java
@@ -19,29 +19,23 @@ import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.icatproject.icat_oaipmh.exceptions.InternalException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.ProcessingInstruction;
 
 public class XmlResponse {
 
-    private static final Logger logger = LoggerFactory.getLogger(XmlResponse.class);
-
     private DocumentBuilderFactory factory;
     private Document document;
 
-    public XmlResponse() throws InternalException {
+    public XmlResponse() throws IllegalStateException {
         factory = DocumentBuilderFactory.newInstance();
 
         DocumentBuilder builder = null;
         try {
             builder = factory.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
-            logger.error(e.getMessage());
-            throw new InternalException();
+            throw new IllegalStateException(e.getMessage(), e.getCause());
         }
 
         document = builder.newDocument();
@@ -163,7 +157,7 @@ public class XmlResponse {
         xmlElement.appendChild(el);
     }
 
-    public String transformXml(Templates template) throws InternalException {
+    public String transformXml(Templates template) throws IllegalStateException {
         Transformer transformer = null;
         Document doc = null;
         String output = null;
@@ -187,8 +181,7 @@ public class XmlResponse {
             transformer.transform(source, new StreamResult(writer));
             output = writer.getBuffer().toString();
         } catch (TransformerException | ParserConfigurationException e) {
-            logger.error(e.getMessage());
-            throw new InternalException();
+            throw new IllegalStateException(e.getMessage(), e.getCause());
         }
 
         return output;

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -17,6 +17,7 @@
 		accessible.</li>
 		<li>#18: Review example XSLT for creating DataCite metadata</li>
 		<li>Various fixes to ensure compatibility with OAI-PMH.</li>
+		<li>Review exception handling and logging.</li>
 	</ul>
 
 	<h2>1.0.0</h2>

--- a/src/test/java/org/icatproject/icat_oaipmh/integration/TestVerbs.java
+++ b/src/test/java/org/icatproject/icat_oaipmh/integration/TestVerbs.java
@@ -157,7 +157,7 @@ public class TestVerbs extends BaseTest {
 
 	@Test
 	public void testListMetadataFormatsInvalidIdentifier() throws Exception {
-		Document response = request("?verb=ListMetadataFormats&identifier=invalid");
+		Document response = request("?verb=ListMetadataFormats&identifier=oai:invalid:stud/0");
 
 		Node error = getXmlNode(response, "error");
 		NamedNodeMap attributes = error.getAttributes();
@@ -197,6 +197,16 @@ public class TestVerbs extends BaseTest {
 		NamedNodeMap attributes = error.getAttributes();
 		Node errorCode = attributes.getNamedItem("code");
 		assertEquals("badArgument", errorCode.getTextContent());
+	}
+
+	@Test
+	public void testGetRecordInvalidIdentifier() throws Exception {
+		Document response = request("?verb=GetRecord&metadataPrefix=oai_datacite&identifier=oai:invalid:stud/0");
+
+		Node error = getXmlNode(response, "error");
+		NamedNodeMap attributes = error.getAttributes();
+		Node errorCode = attributes.getNamedItem("code");
+		assertEquals("idDoesNotExist", errorCode.getTextContent());
 	}
 
 	@Test


### PR DESCRIPTION
I noticed that icat.oaipmh currently doesn't have very consistent exception handling rules and in particular sometimes doesn't produce much useful logging output.

The changes in this PR aim to hopefully make it a little bit easier to debug when something goes wrong in the future.

I think it would make sense to merge these changes before the release of version 1.1.0, even though this might postpone the release yet again by a few days. Most of the changes are just minor anyway.