### PR TITLE
Keep exception info during initialization

### DIFF
--- a/src/main/java/org/icatproject/icat_oaipmh/RequestInterface.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/RequestInterface.java
@@ -131,9 +131,9 @@ public class RequestInterface {
 		} catch (CheckedPropertyException | FileNotFoundException | SecurityException | NumberFormatException
 				| TransformerConfigurationException | URISyntaxException e) {
 			logger.error(e.getMessage());
-			throw new IllegalStateException();
+			throw new IllegalStateException("Configuration exception during initialization", e);
 		} catch (InternalException e) {
-			throw new IllegalStateException();
+			throw new IllegalStateException("Internal exception during initialization", e);
 		}
 
 		logger.info("Initialized RequestInterface");

--- a/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/ResponseBuilder.java
@@ -52,7 +52,7 @@ public class ResponseBuilder {
             this.restIcat = new ICATInterface(icatUrl);
         } catch (URISyntaxException | IcatException e) {
             logger.error(e.getMessage());
-            throw new InternalException();
+            throw new InternalException("Exception setting up ICAT interface", e);
         }
     }
 

--- a/src/main/java/org/icatproject/icat_oaipmh/exceptions/InternalException.java
+++ b/src/main/java/org/icatproject/icat_oaipmh/exceptions/InternalException.java
@@ -5,6 +5,11 @@ public class InternalException extends Exception {
 
 	private int httpStatusCode;
 
+	public InternalException(String message, Throwable cause) {
+		super(message, cause);
+		this.httpStatusCode = 500;
+	}
+
 	public InternalException() {
 		this.httpStatusCode = 500;
 	}


### PR DESCRIPTION
Hi, I had some problems with my configuration whilst setting up this component for ISIS and used the following to help track down where the issues were. Without the line numbers from the stack traces it was hard to tell where in the `try` block the exceptions came from, as it's pretty large.

Not sure if this is something you'd be interested in including, but figured I'd make it available.