### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates every week
+      interval: "weekly"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,6 +23,14 @@ jobs:
           python-version: "3.9.7"
           architecture: x64
 
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       # ICAT Ansible clone and install dependencies
       - name: Checkout icat-ansible
         uses: actions/checkout@v2

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   build_and_tests:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,7 +26,7 @@ jobs:
           architecture: x64
 
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9.7"
           architecture: x64

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Setup Java & Python
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,18 +15,18 @@ jobs:
     steps:
       # Setup Java & Python
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@3f07048e3d294f56e9b90ac5ea2c6f74e9ad0f98 # v3.10.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
         with:
           python-version: "3.9.7"
           architecture: x64
 
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -35,7 +35,7 @@ jobs:
 
       # ICAT Ansible clone and install dependencies
       - name: Checkout icat-ansible
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
@@ -77,7 +77,7 @@ jobs:
           ansible-playbook icat-ansible/icatdb_minimal_hosts.yml -i icat-ansible/hosts --vault-password-file icat-ansible/vault_pass.txt -vv
 
       - name: Checkout icat-oaipmh
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       # Payara must be sourced otherwise the Maven build command fails
       - name: Run Build

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,82 @@
+name: CI Build
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  build_and_tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
+    steps:
+      # Setup Java & Python
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9.7"
+          architecture: x64
+
+      # ICAT Ansible clone and install dependencies
+      - name: Checkout icat-ansible
+        uses: actions/checkout@v2
+        with:
+          repository: icatproject-contrib/icat-ansible
+          path: icat-ansible
+          ref: master
+      - name: Install Ansible
+        run: pip install -r icat-ansible/requirements.txt
+
+      # Prep for running the playbook
+      - name: Create Hosts File
+        run: echo -e "[icatdb_minimal_hosts]\nlocalhost ansible_connection=local" > icat-ansible/hosts
+      - name: Prepare vault pass
+        run: echo -e "icattravispw" > icat-ansible/vault_pass.txt
+      - name: Move vault to directory it'll get detected by Ansible
+        run: mv icat-ansible/vault.yml icat-ansible/group_vars/all
+      - name: Replace default payara user with Actions user
+        run: |
+          sed -i -e "s/^payara_user: \"glassfish\"/payara_user: \"runner\"/" icat-ansible/group_vars/all/vars.yml
+      - name: Add Ansible Role
+        run: |
+          sed -i "/- role: icat_server$/a\
+          \    - role: dev_common" icat-ansible/icatdb_minimal_hosts.yml
+
+      # Force hostname to localhost - bug fix for previous ICAT Ansible issues on Actions
+      - name: Change hostname to localhost
+        run: sudo hostname -b localhost
+
+      # Remove existing MySQL installation so it doesn't interfere with GitHub Actions
+      - name: Remove existing mysql
+        run: |
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+          sudo apt-get remove --purge "mysql*"
+          sudo rm -rf /var/lib/mysql* /etc/mysql
+
+      # Create local instance of ICAT
+      - name: Run ICAT Ansible Playbook
+        run: |
+          ansible-playbook icat-ansible/icatdb_minimal_hosts.yml -i icat-ansible/hosts --vault-password-file icat-ansible/vault_pass.txt -vv
+
+      - name: Checkout icat-oaipmh
+        uses: actions/checkout@v2
+
+      # Payara must be sourced otherwise the Maven build command fails
+      - name: Run Build
+        run: |
+          grep payara ~/.bash_profile > payara_path_command
+          source payara_path_command
+          mvn install -DskipTests
+
+      - name: After Failure
+        if: ${{ failure() }}
+        run: |
+          cat /home/runner/logs/icat_oaipmh.log
+          cat /home/runner/logs/icat.log
+          cat /home/runner/payara*/glassfish/domains/domain1/logs/server.log

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -35,7 +35,7 @@ jobs:
 
       # ICAT Ansible clone and install dependencies
       - name: Checkout icat-ansible
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
@@ -77,7 +77,7 @@ jobs:
           ansible-playbook icat-ansible/icatdb_minimal_hosts.yml -i icat-ansible/hosts --vault-password-file icat-ansible/vault_pass.txt -vv
 
       - name: Checkout icat-oaipmh
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Payara must be sourced otherwise the Maven build command fails
       - name: Run Build

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -45,6 +45,8 @@ jobs:
           sed -i -e "s/^payara_user: \"glassfish\"/payara_user: \"runner\"/" icat-ansible/group_vars/all/vars.yml
       - name: Add Ansible Role
         run: |
+          sed -i "/- role: authn_anon$/a\
+          \    - role: authn_db" icat-ansible/icatdb_minimal_hosts.yml
           sed -i "/- role: icat_server$/a\
           \    - role: dev_common" icat-ansible/icatdb_minimal_hosts.yml
 
@@ -73,6 +75,9 @@ jobs:
           grep payara ~/.bash_profile > payara_path_command
           source payara_path_command
           mvn install -DskipTests
+
+      - name: Run Integration Tests
+        run: mvn failsafe:integration-test failsafe:verify -B
 
       - name: After Failure
         if: ${{ failure() }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # icat_oaipmh: An OAI-PMH interface for ICAT
 
+[![Build Status](https://github.com/icatproject/icat.oaipmh/workflows/CI%20Build/badge.svg?branch=master)](https://github.com/icatproject/icat.oaipmh/actions?query=workflow%3A%22CI+Build%22)
+
 General installation instructions are at http://www.icatproject.org/installation/component
 
 Specific installation instructions are at http://www.icatproject.org/mvn/site/icat/oaipmh/${project.version}/installation.html


### PR DESCRIPTION
Adds CI using GitHub Actions and a status badge to the README. The status badge will start working once this PR gets merged into `master`, but this is the status badge for this branch to prove that it works:

[![Build Status](https://github.com/icatproject/icat.oaipmh/workflows/CI%20Build/badge.svg?branch=add-ci)](https://github.com/icatproject/icat.oaipmh/actions?query=workflow%3A%22CI+Build%22)

- [x] Should run maven build
- [x] Should run integration tests
- [x] Java 8 CI should pass
- [x] Java 11 CI should pass