### PR TITLE
Do not overwrite setup.properties or logback.xml in the test install directory

### DIFF
--- a/src/test/scripts/prepare_test.py
+++ b/src/test/scripts/prepare_test.py
@@ -48,11 +48,12 @@ finally:
 for f in glob.glob("src/test/install/*.war"):
     os.remove(f)
 
-with open("src/test/install/setup.properties", "wt") as f:
-    print("secure         = true", file=f)
-    print("container      = Glassfish", file=f)
-    print("home           = %s" % containerHome, file=f)
-    print("port           = 4848", file=f)
+if not os.path.exists("src/test/install/setup.properties"):
+    with open("src/test/install/setup.properties", "wt") as f:
+        print("secure         = true", file=f)
+        print("container      = Glassfish", file=f)
+        print("home           = %s" % containerHome, file=f)
+        print("port           = 4848", file=f)
 
 with open("src/test/install/run.properties.example", "wt") as f:
     pass
@@ -64,10 +65,11 @@ with ZipFile(glob.glob("target/icat.oaipmh-*-distro.zip")[0]) as z:
     with open("src/test/install/setup_utils.py", "wb") as f:
         f.write(z.read("icat.oaipmh/setup_utils.py"))
 
-with open("src/main/resources/logback.xml", "rt") as s:
-    with open("src/test/install/logback.xml", "wt") as f:
-        t = Template(s.read()).substitute(subst)
-        print(t, end="", file=f)
+if not os.path.exists("src/test/install/logback.xml"):
+    with open("src/main/resources/logback.xml", "rt") as s:
+        with open("src/test/install/logback.xml", "wt") as f:
+            t = Template(s.read()).substitute(subst)
+            print(t, end="", file=f)
 
 p = subprocess.Popen(["./setup", "install"], cwd="src/test/install")
 p.wait()


### PR DESCRIPTION
The preparation script for the integration tests `prepare_test.py` sets up the install directory `src/test/install` to install `icat.oaipmh` from there to the Payara server, creating all the needed files. While doing that, it blindly overwrite existing files. This is intended in the case of `run.properties`, because the integration tests may need to be run for different deployment scenarios that need to be configured in `run.properties`. But it is bad in the case of `setup.properties` and `logback.xml`, because they may need to be manually adapted to the test environment.

The present PR changes the behavior of the script to not overwrite existing `setup.properties` or `logback.xml`. In the default case, starting from an empty `src/test/install` directory, this makes no difference. But it is now possible to tweak the test environment by putting acordingly adapted versions of the files in the directory before running the tests.